### PR TITLE
Create USDC ATA for owner if it does not exist.

### DIFF
--- a/src/bots/jitMaker.ts
+++ b/src/bots/jitMaker.ts
@@ -580,7 +580,7 @@ export class JitMakerBot implements Bot {
 		const takerUserStatsPublicKey = takerUserStats.userStatsAccountPublicKey;
 		const referrerInfo = takerUserStats.getReferrerInfo();
 
-		return await this.clearingHouse.placeAndMakeSpotOrder(
+		return await this.clearingHouse.placeAndMakePerpOrder(
 			{
 				orderType: OrderType.LIMIT,
 				marketIndex: action.marketIndex,

--- a/src/bots/jitMaker.ts
+++ b/src/bots/jitMaker.ts
@@ -131,15 +131,6 @@ export class JitMakerBot implements Bot {
 		logger.info(`${this.name} initing`);
 		const initPromises: Array<Promise<any>> = [];
 
-		this.dlob = new DLOB(
-			this.clearingHouse.getPerpMarketAccounts(),
-			this.clearingHouse.getSpotMarketAccounts(),
-			this.clearingHouse.getStateAccount(),
-			this.userMap,
-			true
-		);
-		initPromises.push(this.dlob.init());
-
 		this.userMap = new UserMap(
 			this.clearingHouse,
 			this.clearingHouse.userAccountSubscriptionConfig
@@ -151,6 +142,15 @@ export class JitMakerBot implements Bot {
 			this.clearingHouse.userAccountSubscriptionConfig
 		);
 		initPromises.push(this.userStatsMap.fetchAllUserStats());
+
+		this.dlob = new DLOB(
+			this.clearingHouse.getPerpMarketAccounts(),
+			this.clearingHouse.getSpotMarketAccounts(),
+			this.clearingHouse.getStateAccount(),
+			this.userMap,
+			true
+		);
+		initPromises.push(this.dlob.init());
 
 		this.agentState = {
 			stateType: new Map<number, StateType>(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import { FloatingPerpMakerBot } from './bots/floatingMaker';
 import { Bot } from './types';
 import { Metrics } from './metrics';
 import { PnlSettlerBot } from './bots/pnlSettler';
+import { getOrCreateAssociatedTokenAccount } from './utils';
 
 require('dotenv').config();
 const driftEnv = process.env.ENV as DriftEnv;
@@ -269,11 +270,10 @@ const runBot = async () => {
 	);
 	logger.info(`Wallet pubkey: ${wallet.publicKey.toBase58()}`);
 	logger.info(` . SOL balance: ${lamportsBalance / 10 ** 9}`);
-	const tokenAccount = await Token.getAssociatedTokenAddress(
-		ASSOCIATED_TOKEN_PROGRAM_ID,
-		TOKEN_PROGRAM_ID,
+	const tokenAccount = await getOrCreateAssociatedTokenAccount(
+		connection,
 		new PublicKey(constants.devnet.USDCMint),
-		wallet.publicKey
+		wallet
 	);
 	const usdcBalance = await connection.getTokenAccountBalance(tokenAccount);
 	logger.info(` . USDC balance: ${usdcBalance.value.uiAmount}`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,10 @@ import {
 } from '@solana/spl-token';
 import { Connection, PublicKey, Transaction } from '@solana/web3.js';
 
+export const TOKEN_FAUCET_PROGRAM_ID = new PublicKey(
+	'V4v1mQiAdLz4qwckEb45WqHYceYizoib39cDBHSWfaB'
+);
+
 export async function getOrCreateAssociatedTokenAccount(
 	connection: Connection,
 	mint: PublicKey,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,38 @@
+import { Wallet } from '@drift-labs/sdk';
+import {
+	Token,
+	TOKEN_PROGRAM_ID,
+	ASSOCIATED_TOKEN_PROGRAM_ID,
+} from '@solana/spl-token';
+import { Connection, PublicKey, Transaction } from '@solana/web3.js';
+
+export async function getOrCreateAssociatedTokenAccount(
+	connection: Connection,
+	mint: PublicKey,
+	wallet: Wallet
+): Promise<PublicKey> {
+	const associatedTokenAccount = await Token.getAssociatedTokenAddress(
+		ASSOCIATED_TOKEN_PROGRAM_ID,
+		TOKEN_PROGRAM_ID,
+		mint,
+		wallet.publicKey
+	);
+
+	const accountInfo = await connection.getAccountInfo(associatedTokenAccount);
+	if (accountInfo == null) {
+		const tx = new Transaction().add(
+			Token.createAssociatedTokenAccountInstruction(
+				ASSOCIATED_TOKEN_PROGRAM_ID,
+				TOKEN_PROGRAM_ID,
+				mint,
+				associatedTokenAccount,
+				wallet.publicKey,
+				wallet.publicKey
+			)
+		);
+		const txSig = await connection.sendTransaction(tx, [wallet.payer]);
+		await connection.confirmTransaction(txSig, 'confirmed');
+	}
+
+	return associatedTokenAccount;
+}


### PR DESCRIPTION
Fix for: USDC token account does not exist for new user. [#13](https://github.com/drift-labs/keeper-bots-v2/issues/13)
Fix for: Devnet deposit instruction fails because no collateral. [#15](https://github.com/drift-labs/keeper-bots-v2/issues/15)
Fix for: UserMap is not created before being used in DLOB ctor. [#16](https://github.com/drift-labs/keeper-bots-v2/issues/16)
Fix for: JIT Maker tried to place a spot order instead of a perp. [#17](https://github.com/drift-labs/keeper-bots-v2/issues/17)