### PR TITLE
Add Webhook Alerts, Fix USDC on Mainnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"async": "^3.2.2",
 		"async-mutex": "0.3.2",
 		"aws-sdk": "^2.1062.0",
+		"axios": "^1.1.3",
 		"commander": "^9.4.0",
 		"dotenv": "^10.0.0",
 		"typescript": "4.5.4",

--- a/src/bots/filler.ts
+++ b/src/bots/filler.ts
@@ -56,6 +56,7 @@ import {
 import { logger } from '../logger';
 import { Bot } from '../types';
 import { RuntimeSpec, metricAttrFromUserAccount } from '../metrics';
+import { webhookMessage } from '../webhook';
 
 const MAX_TX_PACK_SIZE = 900; //1232;
 const CU_PER_FILL = 200_000; // CU cost for a successful fill
@@ -1072,6 +1073,10 @@ export class FillerBot implements Bot {
 						logger.info(
 							`parse logs took ${processBulkFillLogsDuration}ms, filled ${successfulFills}`
 						);
+						if(successfulFills > 0){
+							webhookMessage(`FILLER: :white_check_mark: orders filled for users, parse logs took ${processBulkFillLogsDuration}ms, filled ${successfulFills}` );
+						}
+							
 
 						// record successful fills
 						const user = this.driftClient.getUser();

--- a/src/bots/liquidator.ts
+++ b/src/bots/liquidator.ts
@@ -48,6 +48,7 @@ import {
 import { logger } from '../logger';
 import { Bot } from '../types';
 import { RuntimeSpec, metricAttrFromUserAccount } from '../metrics';
+import { webhookMessage } from '../webhook';
 
 const USER_MAP_RESYNC_COOLDOWN_SLOTS = 300;
 
@@ -185,6 +186,7 @@ async function liqPerpPnl(
 				)
 				.then((tx) => {
 					logger.info(`liquidateBorrowForPerpPnl tx: ${tx}`);
+					webhookMessage(`liquidateBorrowForPerpPnl tx: ${tx}`);
 				})
 				.catch((e) => {
 					logger.error('Error in liquidateBorrowForPerpPnl');
@@ -213,6 +215,7 @@ async function liqPerpPnl(
 			)
 			.then((tx) => {
 				logger.info(`did liquidatePerpPnlForDeposit tx: ${tx}`);
+				webhookMessage(`did liquidatePerpPnlForDeposit tx: ${tx}`);
 			})
 			.catch((e) => {
 				console.error(e);
@@ -754,12 +757,16 @@ export class LiquidatorBot implements Bot {
 			logger.info(
 				`Resolving perp market for userAcc: ${userKey.toBase58()}, marketIndex: ${perpIdx}`
 			);
+			webhookMessage(`Resolving perp market for userAcc: ${userKey.toBase58()}, marketIndex: ${perpIdx}`);
 			const start = Date.now();
 			this.driftClient
 				.resolvePerpBankruptcy(userKey, userAcc, perpIdx)
 				.then((tx) => {
 					logger.info(
 						`Resolved perp bankruptcy for userAcc: ${userKey.toBase58()}, marketIndex: ${perpIdx}: ${tx}`
+					);
+					webhookMessage(
+						`LIQ: Resolved perp market for userAcc: ${userKey.toBase58()}, marketIndex: ${perpIdx}: ${tx}`
 					);
 				})
 				.catch((e) => {
@@ -779,12 +786,16 @@ export class LiquidatorBot implements Bot {
 			logger.info(
 				`Resolving spot market for userAcc: ${userKey.toBase58()}, marketIndex: ${spotIdx}`
 			);
+			webhookMessage(`Resolving spot market for userAcc: ${userKey.toBase58()}, marketIndex: ${spotIdx}`);
 			const start = Date.now();
 			this.driftClient
 				.resolveSpotBankruptcy(userKey, userAcc, spotIdx)
 				.then((tx) => {
 					logger.info(
 						`Resolved spot market for userAcc: ${userKey.toBase58()}, marketIndex: ${spotIdx}: ${tx}`
+					);
+					webhookMessage(
+						`LIQ: Resolved spot market for userAcc: ${userKey.toBase58()}, marketIndex: ${spotIdx}: ${tx}`
 					);
 				})
 				.catch((e) => {
@@ -821,6 +832,7 @@ export class LiquidatorBot implements Bot {
 					await this.tryResolveBankruptUser(user);
 				} else if (user.canBeLiquidated()) {
 					logger.info(`liquidating ${auth}: ${userKey}...`);
+					webhookMessage(`LIQ: liquidating ${auth}: ${userKey} ...`);
 
 					const liquidatorUser = this.driftClient.getUser();
 					const liquidateeUserAccount = user.getUserAccount();
@@ -858,6 +870,12 @@ export class LiquidatorBot implements Bot {
 							)
 							.then((tx) => {
 								logger.info(
+									`liquidateSpot user=${user.userAccountPublicKey.toString()}
+								(deposit_index=${depositMarketIndextoLiq} for borrow_index=${borrowMarketIndextoLiq}
+								maxBorrowAmount=${borrowAmountToLiq.toString()})
+								tx: ${tx}`
+								);
+								webhookMessage(
 									`liquidateSpot user=${user.userAccountPublicKey.toString()}
 								(deposit_index=${depositMarketIndextoLiq} for borrow_index=${borrowMarketIndextoLiq}
 								maxBorrowAmount=${borrowAmountToLiq.toString()})
@@ -925,11 +943,13 @@ export class LiquidatorBot implements Bot {
 								)
 								.then((tx) => {
 									logger.info(`liquidatePerp tx: ${tx}`);
+									webhookMessage(`LIQ: :money_mouth: liquidatePerp tx: ${tx}`);
 								})
 								.catch((e) => {
 									logger.error(
 										`Error liquidating auth: ${auth}, user: ${userKey}`
 									);
+									webhookMessage(`LIQ: :x: Error liquidating auth: ${auth}, user: ${userKey}`);
 									console.error(e);
 								})
 								.finally(() => {

--- a/src/bots/trigger.ts
+++ b/src/bots/trigger.ts
@@ -17,6 +17,7 @@ import { logger } from '../logger';
 import { Bot } from '../types';
 import { getErrorCode } from '../error';
 import { Metrics } from '../metrics';
+import { webhookMessage } from '../webhook';
 
 const dlobMutexError = new Error('dlobMutex timeout');
 const USER_MAP_RESYNC_COOLDOWN_SLOTS = 200;
@@ -203,6 +204,8 @@ export class TriggerBot implements Bot {
 							`Triggered perp user (account: ${nodeToTrigger.node.userAccount.toString()}) perp order: ${nodeToTrigger.node.order.orderId.toString()}`
 						);
 						logger.info(`Tx: ${txSig}`);
+						webhookMessage( `TRIGGER: :gear: Triggered perp user (account: ${nodeToTrigger.node.userAccount.toString()}) perp order: ${nodeToTrigger.node.order.orderId.toString()}` );
+						webhookMessage( `TRIGGER: :gear: Tx: ${txSig}`);
 					})
 					.catch((error) => {
 						const errorCode = getErrorCode(error);
@@ -269,6 +272,8 @@ export class TriggerBot implements Bot {
 							`Triggered user (account: ${nodeToTrigger.node.userAccount.toString()}) spot order: ${nodeToTrigger.node.order.orderId.toString()}`
 						);
 						logger.info(`Tx: ${txSig}`);
+						webhookMessage( `TRIGGER: :gear: Triggered user (account: ${nodeToTrigger.node.userAccount.toString()}) spot order: ${nodeToTrigger.node.order.orderId.toString()}` );
+						webhookMessage( `TRIGGER: :gear: Tx: ${txSig}`);
 					})
 					.catch((error) => {
 						const errorCode = getErrorCode(error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ import {
 	TOKEN_FAUCET_PROGRAM_ID,
 } from './utils';
 import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
+import { webhookMessage } from './webhook';
 import { bs58 } from '@project-serum/anchor/dist/cjs/utils/bytes';
 
 require('dotenv').config();
@@ -549,6 +550,7 @@ const runBot = async () => {
 	await Promise.all(bots.map((bot) => bot.init()));
 
 	logger.info(`starting bots`);
+	webhookMessage(`starting bots`);
 	await Promise.all(
 		bots.map((bot) => bot.startIntervalLoop(bot.defaultIntervalMs))
 	);

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
 import { bs58 } from '@project-serum/anchor/dist/cjs/utils/bytes';
 
 require('dotenv').config();
-const driftEnv = process.env.ENV as DriftEnv;
+const driftEnv = (process.env.ENV || 'devnet') as DriftEnv;
 const commitHash = process.env.COMMIT;
 //@ts-ignore
 const sdkConfig = initialize({ env: process.env.ENV });
@@ -286,7 +286,7 @@ const runBot = async () => {
 	try {
 		const tokenAccount = await getOrCreateAssociatedTokenAccount(
 			connection,
-			new PublicKey(constants.devnet.USDCMint),
+			new PublicKey(constants[driftEnv].USDCMint),
 			wallet
 		);
 		const usdcBalance = await connection.getTokenAccountBalance(tokenAccount);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,11 @@
 import { DLOB, WrappedEvent } from '@drift-labs/sdk';
 
 export const constants = {
-	devnet: {
+	'devnet': {
 		USDCMint: '8zGuJQqwhZafTah7Uc7Z4tXRnguqkn5KLFAP8oV6PHe2',
+	},
+	'mainnet-beta': {
+		USDCMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
 	},
 };
 

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+require('dotenv').config();
+import { logger } from './logger';
+
+export async function webhookMessage(message: string, webhookUrl?: string, prefix?: string): Promise<void> {
+    if(webhookUrl || process.env.WEBHOOK_URL) {
+        const webhook = webhookUrl || process.env.WEBHOOK_URL;
+        const fullMessage = prefix ? (prefix + message) : message;
+        if (fullMessage && webhook) {
+                try {
+                        const data = { content: fullMessage };
+                        axios.post(webhook, data);
+                } catch (err) {
+                        logger.info('webhook error');
+                }
+        }
+    }
+}


### PR DESCRIPTION
First Commit: [9c5835b](https://github.com/WaggMe/drift-v2-keeper-bots/commit/9c5835bd3345c0f15ab0011591e517ac93b75a0f)
- adds USDCMint information to types.ts
- updates index.ts to correctly fetch USDCMint based on network

Second Commit: [e006cc6](https://github.com/WaggMe/drift-v2-keeper-bots/commit/e006cc6583a784f33c221fcd5c8aa0378cc6b191)
- create webhook.ts for webhook alerts with `axios`
- add webhook alerts to filler.ts, trigger.ts, liquidator.ts
- add webhook alert when bot restart to index.ts