### PR TITLE
BUGFIX: Liquidator wasn't settling perp balances

### DIFF
--- a/src/bots/liquidator.ts
+++ b/src/bots/liquidator.ts
@@ -879,11 +879,11 @@ export class LiquidatorBot implements Bot {
 			const perpMarket = this.driftClient.getPerpMarketAccount(
 				position.marketIndex
 			)!;
-			if (position.baseAssetAmount.abs().lt(perpMarket.amm.minOrderSize)) {
-				continue;
-			}
-
 			if (!position.baseAssetAmount.isZero()) {
+				if (position.baseAssetAmount.abs().lt(perpMarket.amm.minOrderSize)) {
+					continue;
+				}
+
 				const orderParams = this.getOrderParamsForPerpDerisk(
 					userAccount.subAccountId,
 					position


### PR DESCRIPTION
The loop bailed out if the base asset amount was less than the min order size for the market, so it would not set balances on a zero position.