### PR TITLE
New jito filler strategy

### DIFF
--- a/example.config.yaml
+++ b/example.config.yaml
@@ -3,7 +3,7 @@ global:
   driftEnv: mainnet-beta
 
   # RPC endpoint to use
-  endpoint: https://api.mainnet-beta.solana.com
+  endpoint: https://you-need-your-own-rpc.com
 
   # Custom websocket endpoint to use (if null will be determined from `endpoint``)
   # Note: the default wsEndpoint value simply replaces http(s) with ws(s), so if

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -61,6 +61,18 @@ global:
   bulkAccountLoaderPollingInterval: 5000
 
   useJito: false
+  # 'exclusive' or 'hybrid'. 'hybrid' will attempt to send txs through normal means when there is no jito leader.
+  # hybrid may not work well if using high throughput bots such as a filler depending on infra limitations.
+  jitoStrategy: exclusive
+  # the minimum tip to pay
+  jitoMinBundleTip: 10000
+  # the maximum tip to pay (will pay this once jitoMaxBundleFailCount is hit)
+  jitoMaxBundleTip: 100000
+  # the number of failed bundles (accepted but not landed) before tipping the max tip
+  jitoMaxBundleFailCount: 200
+  # the tip multiplier to use when tipping the max tip
+  # controls superlinearity (1 = linear, 2 = slightly-superlinear, 3 = more-superlinear, ...)
+  jitoTipMultiplier: 3
   jitoBlockEngineUrl: frankfurt.mainnet.block-engine.jito.wtf
   jitoAuthPrivateKey: /path/to/jito/bundle/signing/key/auth.json
 

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -61,9 +61,12 @@ global:
   bulkAccountLoaderPollingInterval: 5000
 
   useJito: false
-  # 'exclusive' or 'hybrid'. 'hybrid' will attempt to send txs through normal means when there is no jito leader.
+  # one of: ['non-jito-only', 'jito-only', 'hybrid'].
+  # * non-jito-only: will only send txs to RPC when there is no active jito leader
+  # * jito-only: will only send txs via bundle when there is an active jito leader
+  # * hybrid: will attempt to send bundles when active jito leader, and use RPC when not
   # hybrid may not work well if using high throughput bots such as a filler depending on infra limitations.
-  jitoStrategy: exclusive
+  jitoStrategy: jito-only
   # the minimum tip to pay
   jitoMinBundleTip: 10000
   # the maximum tip to pay (will pay this once jitoMaxBundleFailCount is hit)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
 		"axios": "^1.1.3",
 		"commander": "^9.4.0",
 		"dotenv": "^10.0.0",
-		"jito-ts": "^2.2.0",
+		"jito-ts": "3.0.1",
+		"lru-cache": "^10.2.0",
 		"typescript": "4.5.4",
 		"winston": "^3.8.1",
 		"yaml": "^2.2.1"

--- a/src/bots/filler.ts
+++ b/src/bots/filler.ts
@@ -2210,7 +2210,11 @@ export class FillerBot implements Bot {
 	}
 
 	protected canSendOutsideJito(): boolean {
-		return !this.usingJito() || this.bundleSender?.strategy === 'hybrid';
+		return (
+			!this.usingJito() ||
+			this.bundleSender?.strategy === 'non-jito-only' ||
+			this.bundleSender?.strategy === 'hybrid'
+		);
 	}
 
 	protected slotsUntilJitoLeader(): number | undefined {

--- a/src/bots/filler.ts
+++ b/src/bots/filler.ts
@@ -1320,6 +1320,7 @@ export class FillerBot implements Bot {
 			// @ts-ignore;
 			tx.sign([this.driftClient.wallet.payer]);
 			await this.sendTxThroughJito(tx, fillTxId);
+			this.removeFillingNodes(nodesSent);
 		} else if (this.canSendOutsideJito()) {
 			estTxSize = tx.message.serialize().length;
 			const acc = tx.message.getAccountKeys({
@@ -2218,7 +2219,7 @@ export class FillerBot implements Bot {
 	}
 
 	protected slotsUntilJitoLeader(): number | undefined {
-		if (!this.usingJito) {
+		if (!this.usingJito()) {
 			return undefined;
 		}
 		return this.bundleSender?.slotsUntilNextLeader();

--- a/src/bots/fillerLite.ts
+++ b/src/bots/fillerLite.ts
@@ -8,11 +8,10 @@ import {
 	User,
 	PriorityFeeSubscriber,
 	DataAndSlot,
+	BlockhashSubscriber,
 } from '@drift-labs/sdk';
 
-import { Keypair, PublicKey } from '@solana/web3.js';
-
-import { SearcherClient } from 'jito-ts/dist/sdk/block-engine/searcher';
+import { PublicKey } from '@solana/web3.js';
 
 import { logger } from '../logger';
 import { FillerConfig } from '../config';
@@ -21,6 +20,7 @@ import { webhookMessage } from '../webhook';
 import { FillerBot, SETTLE_POSITIVE_PNL_COOLDOWN_MS } from './filler';
 
 import { sleepMs } from '../utils';
+import { BundleSender } from 'src/bundleSender';
 
 export class FillerLiteBot extends FillerBot {
 	protected orderSubscriber: OrderSubscriber;
@@ -31,9 +31,8 @@ export class FillerLiteBot extends FillerBot {
 		runtimeSpec: RuntimeSpec,
 		config: FillerConfig,
 		priorityFeeSubscriber: PriorityFeeSubscriber,
-		jitoSearcherClient?: SearcherClient,
-		jitoAuthKeypair?: Keypair,
-		tipPayerKeypair?: Keypair
+		blockhashSubscriber: BlockhashSubscriber,
+		bundleSender?: BundleSender
 	) {
 		super(
 			slotSubscriber,
@@ -44,9 +43,8 @@ export class FillerLiteBot extends FillerBot {
 			runtimeSpec,
 			config,
 			priorityFeeSubscriber,
-			jitoSearcherClient,
-			jitoAuthKeypair,
-			tipPayerKeypair
+			blockhashSubscriber,
+			bundleSender
 		);
 
 		this.userStatsMapSubscriptionConfig = {

--- a/src/bundleSender.ts
+++ b/src/bundleSender.ts
@@ -1,0 +1,449 @@
+import { SlotSubscriber } from '@drift-labs/sdk';
+import {
+	Connection,
+	Keypair,
+	LAMPORTS_PER_SOL,
+	PublicKey,
+	VersionedTransaction,
+} from '@solana/web3.js';
+import {
+	SearcherClient,
+	searcherClient,
+} from 'jito-ts/dist/sdk/block-engine/searcher';
+import { Bundle } from 'jito-ts/dist/sdk/block-engine/types';
+import { logger } from './logger';
+import { BundleResult } from 'jito-ts/dist/gen/block-engine/bundle';
+import { LRUCache } from 'lru-cache';
+import WebSocket from 'ws';
+import { bs58 } from '@project-serum/anchor/dist/cjs/utils/bytes';
+
+export const jitoBundlePriceEndpoint =
+	'ws://bundles-api-rest.jito.wtf/api/v1/bundles/tip_stream';
+
+const logPrefix = '[BundleSender]';
+const MS_DELAY_BEFORE_CHECK_INCLUSION = 30_000;
+const MAX_TXS_TO_CHECK = 50;
+
+export type TipStream = {
+	time: string;
+	ts: number; // millisecond timestamp
+	landed_tips_25th_percentile: number; // in SOL
+	landed_tips_50th_percentile: number; // in SOL
+	landed_tips_75th_percentile: number; // in SOL
+	landed_tips_95th_percentile: number; // in SOL
+	landed_tips_99th_percentile: number; // in SOL
+	ema_landed_tips_50th_percentile: number; // in SOL
+};
+
+type BundleStats = {
+	accepted: number;
+	stateAuctionBidRejected: number;
+	winningBatchBidRejected: number;
+	simulationFailure: number;
+	internalError: number;
+	droppedBundle: number;
+
+	/// extra stats
+	droppedPruned: number;
+	droppedBlockhashExpired: number;
+	droppedBlockhashNotFound: number;
+};
+
+export class BundleSender {
+	private ws: WebSocket | undefined;
+	private searcherClient: SearcherClient;
+	private leaderScheduleIntervalId: NodeJS.Timeout | undefined;
+	private checkSentTxsIntervalId: NodeJS.Timeout | undefined;
+	private isSubscribed = false;
+	private shuttingDown = false;
+	private jitoTipAccounts: PublicKey[] = [];
+	private nextJitoLeader?: {
+		currentSlot: number;
+		nextLeaderSlot: number;
+		nextLeaderIdentity: string;
+	};
+	private updatingJitoSchedule = false;
+	private checkingSentTxs = false;
+
+	// if there is a big difference, probably jito ws connection is bad, should resub
+	private bundlesSent = 0;
+	private bundleResultsReceived = 0;
+
+	// `bundleIdToTx` will be populated immediately after sending a bundle.
+	private bundleIdToTx: LRUCache<string, { tx: string; ts: number }>;
+	// `sentTxCache` will only be populated after a bundle result is received.
+	// reason being that sometimes results come really late (like minutes after sending)
+	// unsure if this is a jito issue or this bot is inefficient and holding onto things
+	// for that long. Check txs from this map to see if they landed.
+	private sentTxCache: LRUCache<string, number>;
+
+	/// -1 for each accepted bundle, +1 for each rejected (due to bid, don't count sim errors).
+	private failBundleCount = 0;
+	private countLandedFills = 0;
+	private countDroppedFills = 0;
+
+	private lastTipStream: TipStream | undefined;
+	private bundleStats: BundleStats = {
+		accepted: 0,
+		stateAuctionBidRejected: 0,
+		winningBatchBidRejected: 0,
+		simulationFailure: 0,
+		internalError: 0,
+		droppedBundle: 0,
+
+		// custom stats
+		droppedPruned: 0,
+		droppedBlockhashExpired: 0,
+		droppedBlockhashNotFound: 0,
+	};
+
+	constructor(
+		private connection: Connection,
+		jitoBlockEngineUrl: string,
+		jitoAuthKeypair: Keypair,
+		private tipPayerKeypair: Keypair,
+		private slotSubscriber: SlotSubscriber,
+
+		/// tip algo params
+		public strategy: 'exclusive' | 'hybrid' = 'exclusive',
+		private minBundleTip = 10_000, // cant be lower than this
+		private maxBundleTip = 100_000,
+		private maxFailBundleCount = 100, // at 100 failed txs, can expect tip to become maxBundleTip
+		private tipMultiplier = 3 // bigger == more superlinear, delay the ramp up to prevent overpaying too soon
+	) {
+		this.searcherClient = searcherClient(jitoBlockEngineUrl, jitoAuthKeypair);
+		this.bundleIdToTx = new LRUCache({
+			max: 500,
+		});
+		this.sentTxCache = new LRUCache({
+			max: 500,
+		});
+	}
+
+	slotsUntilNextLeader(): number | undefined {
+		if (!this.nextJitoLeader) {
+			return undefined;
+		}
+		return this.nextJitoLeader.nextLeaderSlot - this.slotSubscriber.getSlot();
+	}
+
+	private incRunningBundleScore(amount = 1) {
+		this.failBundleCount =
+			(this.failBundleCount + amount) % this.maxFailBundleCount;
+	}
+
+	private decRunningBundleScore(amount = 1) {
+		this.failBundleCount = Math.max(this.failBundleCount - amount, 0);
+	}
+
+	private handleBundleResult(bundleResult: BundleResult) {
+		const bundleId = bundleResult.bundleId;
+		const bundlePayload = this.bundleIdToTx.get(bundleId);
+		if (!bundlePayload) {
+			logger.error(
+				`${logPrefix}: got bundle result for unknown bundleId: ${bundleId}`
+			);
+		}
+		const now = Date.now();
+
+		// Update bundle score. -1 for accept, +1 for reject.
+		// Large score === many failures.
+		// If the count is 0, we pay min tip, if max, we pay max tip.
+		if (bundleResult.accepted !== undefined) {
+			this.bundleStats.accepted++;
+			if (bundlePayload !== undefined) {
+				if (now > bundlePayload.ts + MS_DELAY_BEFORE_CHECK_INCLUSION) {
+					logger.error(
+						`${logPrefix}: received a bundle result ${MS_DELAY_BEFORE_CHECK_INCLUSION} ms after sending. tx: ${bundlePayload.tx}, sent at: ${bundlePayload.ts}`
+					);
+				} else {
+					this.sentTxCache.set(bundlePayload.tx, bundlePayload.ts);
+				}
+			}
+		} else if (bundleResult.rejected !== undefined) {
+			if (bundleResult.rejected.droppedBundle !== undefined) {
+				this.bundleStats.droppedBundle++;
+				const msg = bundleResult.rejected.droppedBundle.msg;
+				if (msg.includes('pruned at slot')) {
+					this.bundleStats.droppedPruned++;
+				} else if (msg.includes('blockhash has expired')) {
+					this.bundleStats.droppedBlockhashExpired++;
+				} else if (msg.includes('Blockhash not found')) {
+					this.bundleStats.droppedBlockhashNotFound++;
+				}
+			} else if (bundleResult.rejected.internalError !== undefined) {
+				this.bundleStats.internalError++;
+			} else if (bundleResult.rejected.simulationFailure !== undefined) {
+				this.bundleStats.simulationFailure++;
+			} else if (bundleResult.rejected.stateAuctionBidRejected !== undefined) {
+				this.bundleStats.stateAuctionBidRejected++;
+			} else if (bundleResult.rejected.winningBatchBidRejected !== undefined) {
+				this.bundleStats.winningBatchBidRejected++;
+			}
+		}
+	}
+	private connectJitoTipStream() {
+		if (this.ws !== undefined) {
+			logger.warn(
+				`${logPrefix} Called connectJitoTipStream but this.ws is already connected, disconnecting it...`
+			);
+			this.ws.close();
+			return;
+		}
+
+		this.ws = new WebSocket(jitoBundlePriceEndpoint);
+		this.bundlesSent = 0;
+		this.bundleResultsReceived = 0;
+
+		this.ws.on('message', (data: string) => {
+			const tipStream = JSON.parse(data) as Array<TipStream>;
+			if (tipStream.length > 0) {
+				tipStream[0].ts = new Date(tipStream[0].time).getTime();
+				this.lastTipStream = tipStream[0];
+			}
+		});
+		this.ws.on('close', () => {
+			logger.info(
+				`${logPrefix}: jito ws closed ${
+					this.shuttingDown ? 'shutting down...' : 'reconnecting in 5s...'
+				}`
+			);
+			this.ws = undefined;
+			if (!this.shuttingDown) {
+				setTimeout(this.connectJitoTipStream.bind(this), 5000);
+			}
+		});
+		this.ws.on('error', (e) => {
+			logger.error(`${logPrefix}: jito ws error: ${JSON.stringify(e)}`);
+		});
+	}
+
+	async subscribe() {
+		if (this.isSubscribed) {
+			return;
+		}
+		this.isSubscribed = true;
+		this.shuttingDown = false;
+
+		const tipAccounts = await this.searcherClient.getTipAccounts();
+		this.jitoTipAccounts = tipAccounts.map((k) => new PublicKey(k));
+
+		this.searcherClient.onBundleResult(
+			(bundleResult: BundleResult) => {
+				logger.debug(
+					`${logPrefix}: got bundle result:\n${JSON.stringify(bundleResult)}`
+				);
+				this.bundleResultsReceived++;
+				this.handleBundleResult(bundleResult);
+			},
+			(e) => {
+				const err = e as Error;
+				logger.error(
+					`${logPrefix}: error getting bundle result: ${err.message}: ${e.stack}`
+				);
+			}
+		);
+
+		this.connectJitoTipStream();
+
+		this.slotSubscriber.eventEmitter.on(
+			'newSlot',
+			this.onSlotSubscriberSlot.bind(this)
+		);
+		this.leaderScheduleIntervalId = setInterval(
+			this.updateJitoLeaderSchedule.bind(this),
+			1000
+		);
+		this.checkSentTxsIntervalId = setInterval(
+			this.checkSentTxs.bind(this),
+			10000
+		);
+	}
+
+	async unsubscribe() {
+		if (!this.isSubscribed) {
+			return;
+		}
+		this.shuttingDown = true;
+
+		if (this.ws) {
+			this.ws.close();
+		}
+
+		if (this.leaderScheduleIntervalId) {
+			clearInterval(this.leaderScheduleIntervalId);
+			this.leaderScheduleIntervalId = undefined;
+		}
+
+		if (this.checkSentTxsIntervalId) {
+			clearInterval(this.checkSentTxsIntervalId);
+			this.checkSentTxsIntervalId = undefined;
+		}
+
+		this.isSubscribed = false;
+	}
+
+	private async onSlotSubscriberSlot(slot: number) {
+		if (this.nextJitoLeader) {
+			const jitoSlot = this.nextJitoLeader.nextLeaderSlot;
+			if (slot >= jitoSlot) {
+				if (slot >= jitoSlot - 2) {
+					logger.info(
+						`${logPrefix}: currSlot: ${slot}, next jito leader slot: ${jitoSlot} (in ${
+							jitoSlot - slot
+						} slots)`
+					);
+					this.updateJitoLeaderSchedule();
+				}
+			}
+		}
+	}
+
+	private async checkSentTxs() {
+		if (this.checkingSentTxs) {
+			return;
+		}
+		this.checkingSentTxs = true;
+		try {
+			// find txs in cache ready to check
+			const now = Date.now();
+			const txs = [];
+			for (const [tx, ts] of this.sentTxCache.entries()) {
+				if (now - ts > MS_DELAY_BEFORE_CHECK_INCLUSION) {
+					this.sentTxCache.delete(tx);
+					txs.push(tx);
+				}
+				if (txs.length >= MAX_TXS_TO_CHECK) {
+					break;
+				}
+			}
+			if (txs.length === 0) {
+				logger.info(`${logPrefix} no txs to check...`);
+			} else {
+				const resps = await this.connection.getTransactions(txs, {
+					commitment: 'confirmed',
+					maxSupportedTransactionVersion: 0,
+				});
+				const droppedTxs = resps.filter((tx) => tx === null);
+				const landedTxs = resps.filter((tx) => tx !== null);
+
+				this.countDroppedFills += droppedTxs.length;
+				this.countLandedFills += landedTxs.length;
+				const countBefore = this.failBundleCount;
+				this.incRunningBundleScore(droppedTxs.length);
+				this.decRunningBundleScore(landedTxs.length);
+
+				logger.info(
+					`${logPrefix} Found ${droppedTxs.length} txs dropped, ${landedTxs.length} landed landed, failCount: ${countBefore} -> ${this.failBundleCount}`
+				);
+			}
+		} catch (e) {
+			const err = e as Error;
+			logger.error(
+				`${logPrefix}: error checking sent txs: ${err.message}. ${err.stack}`
+			);
+		} finally {
+			this.checkingSentTxs = false;
+			logger.info(
+				`${logPrefix}: running fail count: ${
+					this.failBundleCount
+				}, totalLandedTxs: ${this.countLandedFills}, totalDroppedTxs: ${
+					this.countDroppedFills
+				}, currentTipAmount: ${this.calculateCurrentTipAmount()}, lastJitoTipStream: ${JSON.stringify(
+					this.lastTipStream
+				)} bundle stats: ${JSON.stringify(this.bundleStats)}`
+			);
+		}
+	}
+
+	private async updateJitoLeaderSchedule() {
+		if (this.updatingJitoSchedule) {
+			return;
+		}
+		this.updatingJitoSchedule = true;
+		try {
+			this.nextJitoLeader = await this.searcherClient.getNextScheduledLeader();
+		} catch (e) {
+			const err = e as Error;
+			logger.error(
+				`${logPrefix}: error checking jito leader schedule: ${err.message}`
+			);
+		} finally {
+			this.updatingJitoSchedule = false;
+		}
+	}
+
+	/**
+	 *
+	 * @returns current tip based on running score
+	 */
+	calculateCurrentTipAmount() {
+		return Math.floor(
+			Math.max(
+				this.lastTipStream?.landed_tips_25th_percentile ?? 0 * LAMPORTS_PER_SOL,
+				this.minBundleTip,
+				Math.min(
+					this.maxBundleTip,
+					Math.pow(
+						this.failBundleCount / this.maxFailBundleCount,
+						this.tipMultiplier
+					) * this.maxBundleTip
+				)
+			)
+		);
+	}
+
+	// Alternatively, don't create the bundle now, but batch them and send them together with 1 tip.
+	// not really confident in doing that in nodejs land, maybe rust filler.
+	async sendTransaction(signedTx: VersionedTransaction, metadata?: string) {
+		if (!this.isSubscribed) {
+			logger.warn(
+				`${logPrefix} You should call bundleSender.subscribe() before sendTransaction()`
+			);
+			await this.subscribe();
+			return;
+		}
+
+		if (this.bundlesSent - this.bundleResultsReceived > 100) {
+			logger.warn(
+				`${logPrefix} sent ${this.bundlesSent} bundles but only redeived ${this.bundleResultsReceived} results, disconnecting jito ws...`
+			);
+			this.ws?.close();
+			return;
+		}
+		this.bundlesSent++;
+
+		let b: Bundle | Error = new Bundle([signedTx], 2);
+
+		const tipAccountToUse =
+			this.jitoTipAccounts[
+				Math.floor(Math.random() * this.jitoTipAccounts.length)
+			];
+
+		b = b.addTipTx(
+			this.tipPayerKeypair!,
+			this.calculateCurrentTipAmount(),
+			tipAccountToUse!,
+			signedTx.message.recentBlockhash
+		);
+		if (b instanceof Error) {
+			logger.error(`${logPrefix} failed to attach tip: ${b.message})`);
+			return;
+		}
+
+		try {
+			const tx = bs58.encode(signedTx.signatures[0]);
+			const bundleId = await this.searcherClient.sendBundle(b);
+			const ts = Date.now();
+			this.bundleIdToTx.set(bundleId, { tx, ts });
+			logger.info(
+				`${logPrefix} sent bundle with uuid ${bundleId} (${tx}: ${ts}) ${metadata}`
+			);
+		} catch (e) {
+			const err = e as Error;
+			logger.error(
+				`${logPrefix} failed to send bundle: ${err.message}. ${err.stack}`
+			);
+		}
+	}
+}

--- a/src/bundleSender.ts
+++ b/src/bundleSender.ts
@@ -105,7 +105,7 @@ export class BundleSender {
 		private slotSubscriber: SlotSubscriber,
 
 		/// tip algo params
-		public strategy: 'exclusive' | 'hybrid' = 'exclusive',
+		public strategy: 'non-jito-only' | 'jito-only' | 'hybrid' = 'jito-only',
 		private minBundleTip = 10_000, // cant be lower than this
 		private maxBundleTip = 100_000,
 		private maxFailBundleCount = 100, // at 100 failed txs, can expect tip to become maxBundleTip

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,8 +101,14 @@ export interface GlobalConfig {
 	bulkAccountLoaderPollingInterval: number;
 
 	useJito?: boolean;
+	jitoStrategy?: 'exclusive' | 'hybrid';
 	jitoBlockEngineUrl?: string;
 	jitoAuthPrivateKey?: string;
+	jitoMinBundleTip?: number;
+	jitoMaxBundleTip?: number;
+	jitoMaxBundleFailCount?: number;
+	jitoTipMultiplier?: number;
+
 	txRetryTimeoutMs?: number;
 	txSenderType?: 'fast' | 'retry';
 	txSkipPreflight?: boolean;
@@ -142,6 +148,11 @@ const defaultConfig: Partial<Config> = {
 		keeperPrivateKey: process.env.KEEPER_PRIVATE_KEY,
 
 		useJito: false,
+		jitoStrategy: 'exclusive',
+		jitoMinBundleTip: 10_000,
+		jitoMaxBundleTip: 100_000,
+		jitoMaxBundleFailCount: 200,
+		jitoTipMultiplier: 3,
 		jitoBlockEngineUrl: process.env.JITO_BLOCK_ENGINE_URL,
 		jitoAuthPrivateKey: process.env.JITO_AUTH_PRIVATE_KEY,
 		txRetryTimeoutMs: parseInt(process.env.TX_RETRY_TIMEOUT_MS ?? '30000'),
@@ -247,6 +258,11 @@ export function loadConfigFromOpts(opts: any): Config {
 			debug: opts.debug ?? false,
 			subaccounts: loadCommaDelimitToArray(opts.subaccount),
 			useJito: opts.useJito ?? false,
+			jitoStrategy: opts.jitoStrategy ?? 'exclusive',
+			jitoMinBundleTip: opts.jitoMinBundleTip ?? 10_000,
+			jitoMaxBundleTip: opts.jitoMaxBundleTip ?? 100_000,
+			jitoMaxBundleFailCount: opts.jitoMaxBundleFailCount ?? 200,
+			jitoTipMultiplier: opts.jitoTipMultiplier ?? 3,
 			txRetryTimeoutMs: parseInt(opts.txRetryTimeoutMs ?? '30000'),
 			txSenderType: opts.txSenderType ?? 'fast',
 			txSkipPreflight: opts.txSkipPreflight ?? false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,7 +101,7 @@ export interface GlobalConfig {
 	bulkAccountLoaderPollingInterval: number;
 
 	useJito?: boolean;
-	jitoStrategy?: 'exclusive' | 'hybrid';
+	jitoStrategy?: 'jito-only' | 'non-jito-only' | 'hybrid';
 	jitoBlockEngineUrl?: string;
 	jitoAuthPrivateKey?: string;
 	jitoMinBundleTip?: number;
@@ -148,7 +148,7 @@ const defaultConfig: Partial<Config> = {
 		keeperPrivateKey: process.env.KEEPER_PRIVATE_KEY,
 
 		useJito: false,
-		jitoStrategy: 'exclusive',
+		jitoStrategy: 'jito-only',
 		jitoMinBundleTip: 10_000,
 		jitoMaxBundleTip: 100_000,
 		jitoMaxBundleFailCount: 200,

--- a/src/index.ts
+++ b/src/index.ts
@@ -565,7 +565,8 @@ const runBot = async () => {
 				},
 				config.botConfigs!.spotFiller!,
 				priorityFeeSubscriber,
-				eventSubscriber
+				eventSubscriber,
+				bundleSender
 			)
 		);
 	}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -404,7 +404,8 @@ export async function simulateAndGetTxWithCUs(
 	opts?: ConfirmOptions,
 	cuLimitMultiplier = 1.0,
 	logSimDuration = false,
-	doSimulation = true
+	doSimulation = true,
+	recentBlockhash?: string
 ): Promise<SimulateAndGetTxWithCUsResponse> {
 	if (ixs.length === 0) {
 		throw new Error('cannot simulate empty tx');
@@ -422,7 +423,8 @@ export async function simulateAndGetTxWithCUs(
 		ixs,
 		lookupTableAccounts,
 		additionalSigners,
-		opts
+		opts,
+		recentBlockhash
 	);
 	if (!doSimulation) {
 		return {
@@ -473,7 +475,8 @@ export async function simulateAndGetTxWithCUs(
 		ixs,
 		lookupTableAccounts,
 		additionalSigners,
-		opts
+		opts,
+		recentBlockhash
 	);
 
 	return {


### PR DESCRIPTION
This adds a new jito strategy with a retrospective delayed-bid pricing algorithm. The new `BundleSender` class opens up websocket connections to the jito relayer to get bundle results and real time tip floors. Technically this should work with other bots without much additional work, but currently only implemented by filler

# why you want this

* no more priority fees (pay bundle tip instead)
* no more failed txs (no wasted fees paid)
* sends bundles instead of transactions (reduce RPC credit usage for metered plans)

# Bundle pricing

The bot constantly monitors its sent bundles and counts the number of net 'failed' bundles (`success count - fail count`). A failed bundle is defined as one that was accepted by a validator, but the tx did not land on chain after a reasonable amount of time (30s). There are numerous reasons why a bundle might fail to land after being accepted (validator ordering causes your tx to fail or bundle was outbid). This strategy assumes 'failed' bundles come from being outbid, so we increase the bid as fail count increases, but do so in a super linear fashion in order not unnecessarily bid more than we need to, superlinearity is tuned by `jitoTipMultiplier`:

<img width="664" alt="image" src="https://github.com/drift-labs/keeper-bots-v2/assets/6348407/7e719297-131b-4681-9ff8-3fdba36024f1">

[`calculateCurrentTipAmount`](https://github.com/drift-labs/keeper-bots-v2/blob/47aa0aeb248f6cc37a6b7d5143b14bbae905a630/src/bundleSender.ts#L380-L394)
 

# New params in `config.yaml`:

These new params in the config file allow you to tweak the pricing curve.
```
global:
  # set to true to enable jito
  useJito: true
  # one of: ['non-jito-only', 'jito-only', 'hybrid'].
  # * non-jito-only: will only send txs to RPC when there is no active jito leader
  # * jito-only: will only send txs via bundle when there is an active jito leader
  # * hybrid: will attempt to send bundles when active jito leader, and use RPC when not
  # hybrid may not work well if using high throughput bots such as a filler depending on infra limitations.
  jitoStrategy: jito-only
  # the minimum tip to pay
  jitoMinBundleTip: 10000
  # the maximum tip to pay (will pay this once jitoMaxBundleFailCount is hit)
  jitoMaxBundleTip: 100000
  # the number of failed bundles (accepted but not landed) before tipping the max tip
  jitoMaxBundleFailCount: 200
  # the tip multiplier to use when tipping the max tip
  # controls superlinearity (1 = linear, 2 = slightly-superlinear, 3 = more-superlinear, ...)
  jitoTipMultiplier: 3
  jitoBlockEngineUrl: frankfurt.mainnet.block-engine.jito.wtf
  jitoAuthPrivateKey: /path/to/jito/bundle/signing/key/auth.json
```

get jito searcher key and block engine URLs: https://jito-labs.gitbook.io/mev/searcher-resources/getting-started