### PR TITLE
make simulateAndGetTxWithCUs safer

### DIFF
--- a/src/bots/fundingRateUpdater.ts
+++ b/src/bots/fundingRateUpdater.ts
@@ -254,16 +254,17 @@ export class FundingRateUpdaterBot implements Bot {
 			}),
 			await this.driftClient.getUpdateFundingRateIx(marketIndex, oracle),
 		];
-		const simResult = await simulateAndGetTxWithCUs(
+		const recentBlockhash =
+			await this.driftClient.connection.getLatestBlockhash('confirmed');
+		const simResult = await simulateAndGetTxWithCUs({
 			ixs,
-			this.driftClient.connection,
-			this.driftClient.txSender,
-			[this.lookupTableAccount!],
-			[],
-			undefined,
-			CU_EST_MULTIPLIER,
-			true
-		);
+			connection: this.driftClient.connection,
+			payerPublicKey: this.driftClient.wallet.publicKey,
+			lookupTableAccounts: [this.lookupTableAccount!],
+			cuLimitMultiplier: CU_EST_MULTIPLIER,
+			doSimulation: true,
+			recentBlockhash: recentBlockhash.blockhash,
+		});
 		logger.info(
 			`[${this.name}] UpdateFundingRate estimated ${simResult.cuEstimate} CUs for market: ${marketIndex}`
 		);

--- a/src/bots/ifRevenueSettler.ts
+++ b/src/bots/ifRevenueSettler.ts
@@ -143,16 +143,17 @@ export class IFRevenueSettlerBot implements Bot {
 				)
 			);
 
-			const simResult = await simulateAndGetTxWithCUs(
+			const recentBlockhash =
+				await this.driftClient.connection.getLatestBlockhash('confirmed');
+			const simResult = await simulateAndGetTxWithCUs({
 				ixs,
-				this.driftClient.connection,
-				this.driftClient.txSender,
-				[this.lookupTableAccount!],
-				[],
-				undefined,
-				1.1,
-				true
-			);
+				connection: this.driftClient.connection,
+				payerPublicKey: this.driftClient.wallet.publicKey,
+				lookupTableAccounts: [this.lookupTableAccount!],
+				cuLimitMultiplier: 1.1,
+				doSimulation: true,
+				recentBlockhash: recentBlockhash.blockhash,
+			});
 			logger.info(
 				`settleRevenueToInsuranceFund on spot market ${spotMarketIndex} estimated to take ${simResult.cuEstimate} CUs.`
 			);

--- a/src/bots/liquidator.ts
+++ b/src/bots/liquidator.ts
@@ -491,18 +491,18 @@ export class LiquidatorBot implements Bot {
 
 		let resp: SimulateAndGetTxWithCUsResponse;
 		try {
-			resp = await simulateAndGetTxWithCUs(
-				fullIxs,
-				this.driftClient.connection,
-				this.driftClient.txSender,
-				luts,
-				[],
-				this.driftClient.opts,
-				1.2,
-				true,
-				undefined,
-				false
-			);
+			const recentBlockhash =
+				await this.driftClient.connection.getLatestBlockhash('confirmed');
+			resp = await simulateAndGetTxWithCUs({
+				ixs: fullIxs,
+				connection: this.driftClient.connection,
+				payerPublicKey: this.driftClient.wallet.publicKey,
+				lookupTableAccounts: luts,
+				cuLimitMultiplier: 1.2,
+				doSimulation: true,
+				dumpTx: false,
+				recentBlockhash: recentBlockhash.blockhash,
+			});
 		} catch (e) {
 			const err = e as Error;
 			logger.error(

--- a/src/bots/makerBidAskTwapCrank.ts
+++ b/src/bots/makerBidAskTwapCrank.ts
@@ -222,16 +222,17 @@ export class MakerBidAskTwapCrank implements Bot {
 		ixs: TransactionInstruction[]
 	): Promise<{ success: boolean; canRetry: boolean }> {
 		try {
-			const simResult = await simulateAndGetTxWithCUs(
+			const recentBlockhash =
+				await this.driftClient.connection.getLatestBlockhash('confirmed');
+			const simResult = await simulateAndGetTxWithCUs({
 				ixs,
-				this.driftClient.connection,
-				this.driftClient.txSender,
-				[this.lookupTableAccount!],
-				[],
-				undefined,
-				CU_EST_MULTIPLIER,
-				true
-			);
+				connection: this.driftClient.connection,
+				payerPublicKey: this.driftClient.wallet.publicKey,
+				lookupTableAccounts: [this.lookupTableAccount!],
+				cuLimitMultiplier: CU_EST_MULTIPLIER,
+				doSimulation: true,
+				recentBlockhash: recentBlockhash.blockhash,
+			});
 			logger.info(
 				`[${this.name}] estimated ${simResult.cuEstimate} CUs for market: ${marketIndex}`
 			);

--- a/src/bots/userIdleFlipper.ts
+++ b/src/bots/userIdleFlipper.ts
@@ -190,16 +190,17 @@ export class UserIdleFlipperBot implements Bot {
 				);
 			}
 
-			const simResult = await simulateAndGetTxWithCUs(
+			const recentBlockhash =
+				await this.driftClient.connection.getLatestBlockhash('confirmed');
+			const simResult = await simulateAndGetTxWithCUs({
 				ixs,
-				this.driftClient.connection,
-				this.driftClient.txSender,
-				[this.lookupTableAccount!],
-				[],
-				undefined,
-				1.1,
-				true
-			);
+				connection: this.driftClient.connection,
+				payerPublicKey: this.driftClient.wallet.publicKey,
+				lookupTableAccounts: [this.lookupTableAccount!],
+				cuLimitMultiplier: 1.1,
+				doSimulation: true,
+				recentBlockhash: recentBlockhash.blockhash,
+			});
 			logger.info(
 				`User idle flipper estimated ${simResult.cuEstimate} CUs for ${usersChunk.length} users.`
 			);

--- a/src/bots/userLpSettler.ts
+++ b/src/bots/userLpSettler.ts
@@ -390,16 +390,17 @@ export class UserLpSettlerBot implements Bot {
 				)),
 			];
 
-			const simResult = await simulateAndGetTxWithCUs(
+			const recentBlockhash =
+				await this.driftClient.connection.getLatestBlockhash('confirmed');
+			const simResult = await simulateAndGetTxWithCUs({
 				ixs,
-				this.driftClient.connection,
-				this.driftClient.txSender,
-				[this.lookupTableAccount!],
-				[],
-				undefined,
-				CU_EST_MULTIPLIER,
-				true
-			);
+				connection: this.driftClient.connection,
+				payerPublicKey: this.driftClient.wallet.publicKey,
+				lookupTableAccounts: [this.lookupTableAccount!],
+				cuLimitMultiplier: CU_EST_MULTIPLIER,
+				doSimulation: true,
+				recentBlockhash: recentBlockhash.blockhash,
+			});
 			logger.info(
 				`Settle LP estimated ${simResult.cuEstimate} CUs for ${ixs.length} settle LPs.`
 			);

--- a/src/bots/userPnlSettler.ts
+++ b/src/bots/userPnlSettler.ts
@@ -604,16 +604,17 @@ export class UserPnlSettlerBot implements Bot {
 				...(await this.driftClient.getSettlePNLsIxs(users, [marketIndex]))
 			);
 
-			const simResult = await simulateAndGetTxWithCUs(
+			const recentBlockhash =
+				await this.driftClient.connection.getLatestBlockhash('confirmed');
+			const simResult = await simulateAndGetTxWithCUs({
 				ixs,
-				this.driftClient.connection,
-				this.driftClient.txSender,
-				[this.lookupTableAccount!],
-				[],
-				undefined,
-				CU_EST_MULTIPLIER,
-				true
-			);
+				connection: this.driftClient.connection,
+				payerPublicKey: this.driftClient.wallet.publicKey,
+				lookupTableAccounts: [this.lookupTableAccount!],
+				cuLimitMultiplier: CU_EST_MULTIPLIER,
+				doSimulation: true,
+				recentBlockhash: recentBlockhash.blockhash,
+			});
 			logger.info(
 				`Settle Pnl estimated ${simResult.cuEstimate} CUs for ${ixs.length} ixs, ${users.length} users.`
 			);

--- a/src/experimental-bots/filler/fillerMultithreaded.ts
+++ b/src/experimental-bots/filler/fillerMultithreaded.ts
@@ -1188,17 +1188,15 @@ export class FillerMultithreaded {
 				);
 			}
 
-			const simResult = await simulateAndGetTxWithCUs(
+			const simResult = await simulateAndGetTxWithCUs({
 				ixs,
-				this.driftClient.connection,
-				this.driftClient.txSender,
-				[this.lookupTableAccount!],
-				[],
-				this.driftClient.opts,
-				SIM_CU_ESTIMATE_MULTIPLIER,
-				this.simulateTxForCUEstimate,
-				await this.getBlockhashForTx()
-			);
+				connection: this.driftClient.connection,
+				payerPublicKey: this.driftClient.wallet.publicKey,
+				lookupTableAccounts: [this.lookupTableAccount!],
+				cuLimitMultiplier: SIM_CU_ESTIMATE_MULTIPLIER,
+				doSimulation: this.simulateTxForCUEstimate,
+				recentBlockhash: await this.getBlockhashForTx(),
+			});
 			this.simulateTxHistogram?.record(simResult.simTxDuration, {
 				type: 'trigger',
 				simError: simResult.simError !== null,
@@ -1545,17 +1543,15 @@ export class FillerMultithreaded {
 						await this.driftClient.getRevertFillIx(user.userAccountPublicKey)
 					);
 				}
-				const simResult = await simulateAndGetTxWithCUs(
+				const simResult = await simulateAndGetTxWithCUs({
 					ixs,
-					this.driftClient.connection,
-					this.driftClient.txSender,
-					[this.lookupTableAccount!],
-					[],
-					this.driftClient.opts,
-					SIM_CU_ESTIMATE_MULTIPLIER,
-					this.simulateTxForCUEstimate,
-					await this.getBlockhashForTx()
-				);
+					connection: this.driftClient.connection,
+					payerPublicKey: this.driftClient.wallet.publicKey,
+					lookupTableAccounts: [this.lookupTableAccount!],
+					cuLimitMultiplier: SIM_CU_ESTIMATE_MULTIPLIER,
+					doSimulation: this.simulateTxForCUEstimate,
+					recentBlockhash: await this.getBlockhashForTx(),
+				});
 				this.simulateTxHistogram?.record(simResult.simTxDuration, {
 					type: 'multiMakerFill',
 					simError: simResult.simError !== null,
@@ -1711,16 +1707,15 @@ export class FillerMultithreaded {
 			);
 		}
 
-		const simResult = await simulateAndGetTxWithCUs(
+		const simResult = await simulateAndGetTxWithCUs({
 			ixs,
-			this.driftClient.connection,
-			this.driftClient.txSender,
-			[this.lookupTableAccount!],
-			[],
-			this.driftClient.opts,
-			SIM_CU_ESTIMATE_MULTIPLIER,
-			this.simulateTxForCUEstimate
-		);
+			connection: this.driftClient.connection,
+			payerPublicKey: this.driftClient.wallet.publicKey,
+			lookupTableAccounts: [this.lookupTableAccount!],
+			cuLimitMultiplier: SIM_CU_ESTIMATE_MULTIPLIER,
+			doSimulation: this.simulateTxForCUEstimate,
+			recentBlockhash: await this.getBlockhashForTx(),
+		});
 		logger.info(
 			`tryFillPerpNode estimated CUs: ${simResult.cuEstimate} (fillTxId: ${fillTxId})`
 		);
@@ -1916,17 +1911,15 @@ export class FillerMultithreaded {
 							))
 						);
 
-						const simResult = await simulateAndGetTxWithCUs(
+						const simResult = await simulateAndGetTxWithCUs({
 							ixs,
-							this.driftClient.connection,
-							this.driftClient.txSender,
-							[this.lookupTableAccount!],
-							[],
-							this.driftClient.opts,
-							SIM_CU_ESTIMATE_MULTIPLIER,
-							this.simulateTxForCUEstimate,
-							await this.getBlockhashForTx()
-						);
+							connection: this.driftClient.connection,
+							payerPublicKey: this.driftClient.wallet.publicKey,
+							lookupTableAccounts: [this.lookupTableAccount!],
+							cuLimitMultiplier: SIM_CU_ESTIMATE_MULTIPLIER,
+							doSimulation: this.simulateTxForCUEstimate,
+							recentBlockhash: await this.getBlockhashForTx(),
+						});
 						this.simulateTxHistogram?.record(simResult.simTxDuration, {
 							type: 'settlePnl',
 							simError: simResult.simError !== null,

--- a/src/experimental-bots/spotFiller/spotFillerMultithreaded.ts
+++ b/src/experimental-bots/spotFiller/spotFillerMultithreaded.ts
@@ -714,16 +714,15 @@ export class SpotFillerMultithreaded {
 				);
 			}
 
-			const simResult = await simulateAndGetTxWithCUs(
+			const simResult = await simulateAndGetTxWithCUs({
 				ixs,
-				this.driftClient.connection,
-				this.driftClient.txSender,
-				[this.driftLutAccount!],
-				[],
-				this.driftClient.opts,
-				SIM_CU_ESTIMATE_MULTIPLIER,
-				this.simulateTxForCUEstimate
-			);
+				connection: this.driftClient.connection,
+				payerPublicKey: this.driftClient.wallet.publicKey,
+				lookupTableAccounts: [this.driftLutAccount!],
+				cuLimitMultiplier: SIM_CU_ESTIMATE_MULTIPLIER,
+				doSimulation: this.simulateTxForCUEstimate,
+				recentBlockhash: await this.getBlockhashForTx(),
+			});
 			this.simulateTxHistogram?.record(simResult.simTxDuration, {
 				type: 'trigger',
 				simError: simResult.simError !== null,
@@ -988,18 +987,16 @@ export class SpotFillerMultithreaded {
 						await this.driftClient.getRevertFillIx(user.userAccountPublicKey)
 					);
 				}
-				const simResult = await simulateAndGetTxWithCUs(
+				const simResult = await simulateAndGetTxWithCUs({
 					ixs,
-					this.driftClient.connection,
-					this.driftClient.txSender,
-					[this.driftLutAccount!],
-					[],
-					this.driftClient.opts,
-					SIM_CU_ESTIMATE_MULTIPLIER,
-					this.simulateTxForCUEstimate,
-					await this.getBlockhashForTx(),
-					false
-				);
+					connection: this.driftClient.connection,
+					payerPublicKey: this.driftClient.wallet.publicKey,
+					lookupTableAccounts: [this.driftLutAccount!],
+					cuLimitMultiplier: SIM_CU_ESTIMATE_MULTIPLIER,
+					doSimulation: this.simulateTxForCUEstimate,
+					recentBlockhash: await this.getBlockhashForTx(),
+					dumpTx: false,
+				});
 				this.simulateTxHistogram?.record(simResult.simTxDuration, {
 					type: 'multiMakerFill',
 					simError: simResult.simError !== null,
@@ -1211,18 +1208,16 @@ export class SpotFillerMultithreaded {
 		const lutAccounts: Array<AddressLookupTableAccount> = [];
 		this.driftLutAccount && lutAccounts.push(this.driftLutAccount);
 		this.driftSpotLutAccount && lutAccounts.push(this.driftSpotLutAccount);
-		const simResult = await simulateAndGetTxWithCUs(
+		const simResult = await simulateAndGetTxWithCUs({
 			ixs,
-			this.driftClient.connection,
-			this.driftClient.txSender,
-			lutAccounts,
-			[],
-			this.driftClient.opts,
-			SIM_CU_ESTIMATE_MULTIPLIER,
-			this.simulateTxForCUEstimate,
-			undefined,
-			false
-		);
+			connection: this.driftClient.connection,
+			payerPublicKey: this.driftClient.wallet.publicKey,
+			lookupTableAccounts: lutAccounts,
+			cuLimitMultiplier: SIM_CU_ESTIMATE_MULTIPLIER,
+			doSimulation: this.simulateTxForCUEstimate,
+			recentBlockhash: await this.getBlockhashForTx(),
+			dumpTx: false,
+		});
 		this.simulateTxHistogram?.record(simResult.simTxDuration, {
 			type: 'spotFill',
 			simError: simResult.simError !== null,


### PR DESCRIPTION
* refactors `simulateAndGetTxWithCUs` to use named params
* `simulateAndGetTxWithCUs` strip out placeholder blockhash if none was provided, this will cause it to throw if user tries to sign that tx after the fact