### PR TITLE
sort user pnl by ascending to prioritize settling negative pnl positions

### DIFF
--- a/src/bots/userPnlSettler.ts
+++ b/src/bots/userPnlSettler.ts
@@ -501,7 +501,7 @@ export class UserPnlSettlerBot implements Bot {
 				);
 
 				const sortedParams = params
-					.sort((a, b) => Math.abs(b.pnl) - Math.abs(a.pnl))
+					.sort((a, b) => a.pnl - b.pnl)
 					.slice(0, this.maxUsersToConsider);
 
 				logger.info(


### PR DESCRIPTION
Sort positions by ascending pnl to prioritize settling users with large negative pnls first. Settling negative pnls fill the pnl pools, and settling negative pnls pull from the pnl pools.