### PR TITLE
Remove async, and fix eslint

### DIFF
--- a/src/bots/filler.ts
+++ b/src/bots/filler.ts
@@ -251,7 +251,7 @@ export class FillerBot implements Bot {
 	protected clockSubscriberTs?: GaugeValue;
 	protected wallClockTs?: GaugeValue;
 
-	protected hasEnoughSolToFill: boolean = false;
+	protected hasEnoughSolToFill = false;
 	protected rebalanceFiller: boolean;
 	protected minGasBalanceToFill: number;
 	protected rebalanceSettledPnlThreshold: BN;
@@ -1547,8 +1547,12 @@ export class FillerBot implements Bot {
 	/**
 	 * Queues up the txSig to be confirmed in a slower loop, and have tx logs handled
 	 * @param txSig
+	 * @param number
+	 * @param nodeFilled
+	 * @param fillTxId
+	 * @param txType
 	 */
-	protected async registerTxSigToConfirm(
+	protected registerTxSigToConfirm(
 		txSig: TransactionSignature,
 		now: number,
 		nodeFilled: Array<NodeToFill>,

--- a/src/bots/fundingRateUpdater.ts
+++ b/src/bots/fundingRateUpdater.ts
@@ -87,7 +87,7 @@ export class FundingRateUpdaterBot implements Bot {
 
 	private watchdogTimerMutex = new Mutex();
 	private watchdogTimerLastPatTime = Date.now();
-	private inProgress: boolean = false;
+	private inProgress = false;
 
 	constructor(driftClient: DriftClient, config: BaseBotConfig) {
 		this.name = config.botId;

--- a/src/bots/spotFiller.ts
+++ b/src/bots/spotFiller.ts
@@ -321,7 +321,7 @@ export class SpotFillerBot implements Bot {
 	protected rebalanceFiller?: boolean;
 	protected jupiterClient?: JupiterClient;
 
-	protected hasEnoughSolToFill: boolean = false;
+	protected hasEnoughSolToFill = false;
 	protected minGasBalanceToFill: number;
 	protected rebalanceSettledPnlThreshold: BN;
 

--- a/src/experimental-bots/filler-common/dlobBuilder.ts
+++ b/src/experimental-bots/filler-common/dlobBuilder.ts
@@ -48,7 +48,7 @@ class DLOBBuilder {
 	public readonly marketType: MarketType;
 	public readonly marketIndexes: number[];
 	public driftClient: DriftClient;
-	public initialized: boolean = false;
+	public initialized = false;
 
 	// only used for spot filler
 	private serumSubscribers?: Map<number, SerumSubscriber>;

--- a/src/experimental-bots/filler/fillerMultithreaded.ts
+++ b/src/experimental-bots/filler/fillerMultithreaded.ts
@@ -176,12 +176,12 @@ export class FillerMultithreaded {
 	private config: FillerMultiThreadedConfig;
 	private subaccount: number;
 
-	private fillTxId: number = 0;
+	private fillTxId = 0;
 	private userStatsMap: UserStatsMap;
 	private throttledNodes = new Map<string, number>();
 	private fillingNodes = new Map<string, number>();
 	private triggeringNodes = new Map<string, number>();
-	private revertOnFailure: boolean = true;
+	private revertOnFailure = true;
 	private lookupTableAccount?: AddressLookupTableAccount;
 	private lastSettlePnl = Date.now() - SETTLE_POSITIVE_PNL_COOLDOWN_MS;
 	private seenFillableOrders = new Set<string>();
@@ -238,7 +238,7 @@ export class FillerMultithreaded {
 	protected jitoBundleCount?: GaugeValue;
 
 	protected rebalanceFiller?: boolean;
-	protected hasEnoughSolToFill: boolean = true;
+	protected hasEnoughSolToFill = true;
 	protected minGasBalanceToFill: number;
 	protected rebalanceSettledPnlThreshold: BN;
 

--- a/src/experimental-bots/spotFiller/spotFillerMultithreaded.ts
+++ b/src/experimental-bots/spotFiller/spotFillerMultithreaded.ts
@@ -190,7 +190,7 @@ export class SpotFillerMultithreaded {
 	private subaccount: number;
 
 	private userStatsMap?: UserStatsMap;
-	protected hasEnoughSolToFill: boolean = true;
+	protected hasEnoughSolToFill = true;
 
 	private phoenixFulfillmentConfigMap: Map<
 		number,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -651,7 +651,7 @@ export function handleSimResultError(
 }
 
 export interface ExtendedTransactionError {
-	InstructionError?: [number, string | object];
+	InstructionError?: [number, string];
 }
 
 export interface CustomError {


### PR DESCRIPTION
- I think we can remove unnecessary `async` at [[src/bots/filler.ts]](https://github.com/drift-labs/keeper-bots-v2/blob/710dc3049b0f5723b67167a75854d4d638162698/src/bots/filler.ts#L1551)
- Fix some eslint issues