### PR TITLE
do tx sending in subprocess

### DIFF
--- a/src/bots/common/processUtils.ts
+++ b/src/bots/common/processUtils.ts
@@ -1,0 +1,35 @@
+import { ChildProcess, fork, SendHandle, Serializable } from 'child_process';
+
+export const spawnChildWithRetry = (
+	relativePath: string,
+	childArgs: string[],
+	processName: string,
+	onMessage: (msg: Serializable, sendHandle: SendHandle) => void,
+	logPrefix = ''
+): ChildProcess => {
+	const child = fork(relativePath, childArgs);
+
+	child.on('message', onMessage);
+
+	child.on('exit', (code: number | null, signal: NodeJS.Signals | null) => {
+		console.log(
+			`${logPrefix} Child process: ${processName} exited with code ${code}, signal: ${signal}`
+		);
+	});
+
+	child.on('error', (err: Error) => {
+		console.error(
+			`${logPrefix} Child process: ${processName} had an error:\n`,
+			err
+		);
+		if (err.message.includes('Channel closed')) {
+			console.error(`Exiting`);
+			process.exit(2);
+		} else {
+			console.log(`${logPrefix} Restarting child process: ${processName}`);
+			spawnChildWithRetry(relativePath, childArgs, processName, onMessage);
+		}
+	});
+
+	return child;
+};

--- a/src/bots/common/threads/txSender.ts
+++ b/src/bots/common/threads/txSender.ts
@@ -1,0 +1,554 @@
+import { logger } from '../../../logger';
+import { sleepMs } from '../../../utils';
+import {
+	IpcMessageMap,
+	IpcMessageTypes,
+	TransactionPayload,
+	TxSenderMetrics,
+} from './types';
+import {
+	simulateAndGetTxWithCUs,
+	SimulateAndGetTxWithCUsResponse,
+} from '../../../utils';
+import { Wallet as AnchorWallet } from '@coral-xyz/anchor';
+import { bs58 } from '@coral-xyz/anchor/dist/cjs/utils/bytes';
+import {
+	BlockhashSubscriber,
+	loadKeypair,
+	SlotSubscriber,
+} from '@drift-labs/sdk';
+import {
+	Connection,
+	BlockhashWithExpiryBlockHeight,
+	ConfirmOptions,
+	TransactionInstruction,
+	TransactionSignature,
+	VersionedTransaction,
+	PublicKey,
+	Signer,
+	AddressLookupTableAccount,
+	Logs,
+	Context,
+} from '@solana/web3.js';
+import { LRUCache } from 'lru-cache';
+
+const CONFIRM_TX_INTERVAL_MS = 15_000;
+const CONFIRM_TX_RATE_LIMIT_BACKOFF_MS = 5_000;
+const TX_CONFIRMATION_BATCH_SIZE = 50;
+const TX_TIMEOUT_THRESHOLD_MS = 1000 * 60 * 10; // 10 minutes
+const LOG_PREFIX = '[TxSender]';
+
+export type TxSenderConfig = {
+	connection: Connection;
+	blockhashSubscriber: BlockhashSubscriber;
+	slotSubscriber: SlotSubscriber;
+	resendInterval: number;
+	sendTxEnabled: boolean;
+};
+
+export class TxSender {
+	private connection: Connection;
+	private additionalSendTxConnections: Connection[];
+	private blockhashSubscriber: BlockhashSubscriber;
+	private slotSubscriber: SlotSubscriber;
+	private sendTxOpts: ConfirmOptions;
+	private running: boolean;
+	private sendTxEnabled: boolean;
+
+	private txConfirmationConnection: Connection;
+	private txToSendPayload: TransactionPayload[];
+	private pendingTxSigsToConfirm = new LRUCache<
+		string,
+		{
+			ts: number;
+			slot: number;
+			simSlot?: number;
+		}
+	>({
+		max: 10_000,
+		ttl: TX_TIMEOUT_THRESHOLD_MS,
+		ttlResolution: 1000,
+		disposeAfter: this.recordEvictedTxSig.bind(this),
+	});
+	private confirmLoopRunning = false;
+	private lastConfirmLoopRunTs = Date.now() - CONFIRM_TX_RATE_LIMIT_BACKOFF_MS;
+	private pendingTxSigsInterval?: NodeJS.Timeout;
+	private signers: Map<string, AnchorWallet> = new Map();
+	private addressLookupTables: Map<string, AddressLookupTableAccount> =
+		new Map();
+
+	private resendInterval: number;
+	private metrics: TxSenderMetrics;
+
+	constructor(config: TxSenderConfig) {
+		this.connection = config.connection;
+		this.txConfirmationConnection = new Connection(
+			'https://api.mainnet-beta.solana.com'
+		);
+		this.blockhashSubscriber = config.blockhashSubscriber;
+		this.slotSubscriber = config.slotSubscriber;
+		this.resendInterval = config.resendInterval ?? 2000;
+		this.additionalSendTxConnections = []; // TODO: pass in additional RPCs to send txs to
+		this.sendTxOpts = {
+			commitment: 'confirmed',
+			maxRetries: 0,
+			skipPreflight: true,
+		};
+		this.sendTxEnabled = config.sendTxEnabled;
+
+		this.running = false;
+		this.txToSendPayload = [];
+		this.metrics = {
+			txEnabled: this.sendTxEnabled ? 1 : 0,
+			txLanded: 0,
+			txAttempted: 0,
+			txDroppedTimeout: 0,
+			txDroppedBlockhashExpired: 0,
+			txFailedSimulation: 0,
+			pendingQueueSize: 0,
+			lruEvictedTxs: 0,
+			confirmQueueSize: 0,
+			txRetried: 0,
+			txConfirmRateLimited: 0,
+			txConfirmedFromWs: 0,
+		};
+		logger.info(
+			`${LOG_PREFIX} TxSender initialized, connection: ${
+				this.connection.rpcEndpoint
+			}, additionalConns: ${this.additionalSendTxConnections
+				.map((conn) => conn.rpcEndpoint)
+				.join(', ')}`
+		);
+	}
+
+	setTransactionsEnabled(state: boolean) {
+		this.sendTxEnabled = state;
+	}
+
+	async subscribe() {
+		let blockhash = this.blockhashSubscriber.getLatestBlockhash(5);
+		while (!blockhash) {
+			logger.info(
+				`${LOG_PREFIX} waiting for blockhash subscriber to update...`
+			);
+			await sleepMs(1000);
+			blockhash = this.blockhashSubscriber.getLatestBlockhash(5);
+		}
+
+		this.running = true;
+		this.startTxSenderLoop();
+
+		this.pendingTxSigsInterval = setInterval(() => {
+			this.confirmPendingTxSigs();
+		}, CONFIRM_TX_INTERVAL_MS);
+	}
+
+	async unsubscribe() {
+		this.running = false;
+		if (this.pendingTxSigsInterval) {
+			clearInterval(this.pendingTxSigsInterval);
+		}
+	}
+
+	getMetrics(): TxSenderMetrics {
+		this.metrics.confirmQueueSize = this.pendingTxSigsToConfirm.size;
+		this.metrics.pendingQueueSize = this.txToSendPayload.length;
+		this.metrics.txEnabled = this.sendTxEnabled ? 1 : 0;
+		return this.metrics;
+	}
+
+	private async listenToTxLogs(accountPubkey: PublicKey) {
+		this.connection.onLogs(
+			accountPubkey,
+			(logs: Logs, ctx: Context) => {
+				// sim result
+				if (
+					logs.signature ===
+					'1111111111111111111111111111111111111111111111111111111111111111'
+				) {
+					return;
+				}
+
+				const txInsert = this.pendingTxSigsToConfirm.get(logs.signature);
+				if (txInsert) {
+					this.pendingTxSigsToConfirm.delete(logs.signature);
+					this.metrics.txConfirmedFromWs++;
+					this.metrics.txLanded++;
+
+					const confirmedAge = Date.now() - txInsert.ts;
+					const slotAge = ctx.slot - txInsert.slot;
+					logger.info(
+						`${LOG_PREFIX} Tx confirmed from ws: ${logs.signature} (${confirmedAge}ms elapsed, slots elapsed: ${slotAge}, current slot: ${ctx.slot}, txSlot: ${txInsert.slot}, txSimSlot: ${txInsert.simSlot})`
+					);
+				}
+			},
+			'confirmed'
+		);
+	}
+
+	private async confirmPendingTxSigs() {
+		const nextTimeCanRun =
+			this.lastConfirmLoopRunTs + CONFIRM_TX_RATE_LIMIT_BACKOFF_MS;
+		if (Date.now() < nextTimeCanRun) {
+			logger.warn(
+				`Skipping confirm loop due to rate limit, next run in ${
+					nextTimeCanRun - Date.now()
+				} ms`
+			);
+			this.metrics.txConfirmRateLimited++;
+			return;
+		}
+		if (this.confirmLoopRunning) {
+			return;
+		}
+		this.confirmLoopRunning = true;
+		if (!this.running) {
+			return;
+		}
+		try {
+			const txEntries = Array.from(this.pendingTxSigsToConfirm.entries());
+			for (let i = 0; i < txEntries.length; i += TX_CONFIRMATION_BATCH_SIZE) {
+				const txSigsBatch = txEntries.slice(i, i + TX_CONFIRMATION_BATCH_SIZE);
+				const txs = await this.txConfirmationConnection.getTransactions(
+					txSigsBatch.map((tx) => tx[0]),
+					{
+						commitment: 'confirmed',
+						maxSupportedTransactionVersion: 0,
+					}
+				);
+				for (let j = 0; j < txs.length; j++) {
+					const txResp = txs[j];
+					const txConfirmationInfo = txSigsBatch[j];
+					const txSig = txConfirmationInfo[0];
+					const txAge = txConfirmationInfo[1].ts - Date.now();
+					if (!this.pendingTxSigsToConfirm.has(txSig)) {
+						continue;
+					}
+					if (txResp === null) {
+						if (Math.abs(txAge) > TX_TIMEOUT_THRESHOLD_MS) {
+							logger.info(
+								`${LOG_PREFIX} Tx not found after ${
+									txAge / 1000
+								}s, untracking: ${txSig}`
+							);
+							this.metrics.txDroppedTimeout++;
+							this.pendingTxSigsToConfirm.delete(txSig);
+						}
+					} else {
+						const confirmedAge =
+							txConfirmationInfo[1].ts / 1000 -
+							(txResp.blockTime ?? Date.now() / 1000);
+						logger.info(
+							`${LOG_PREFIX} Tx landed: ${txSig}, confirmed tx age: ${confirmedAge}s, slot: ${txResp.slot}`
+						);
+						this.metrics.txLanded++;
+						this.pendingTxSigsToConfirm.delete(txSig);
+					}
+					await sleepMs(500);
+				}
+			}
+			// const txSigConfirmDuration = Date.now() - start;
+		} catch (e) {
+			const err = e as Error;
+			if (err.message.includes('429')) {
+				logger.info(
+					`${LOG_PREFIX} Confirming tx loop rate limited: ${err.message}`
+				);
+				this.lastConfirmLoopRunTs =
+					Date.now() + CONFIRM_TX_RATE_LIMIT_BACKOFF_MS;
+			} else {
+				logger.error(
+					`${LOG_PREFIX} Other error confirming tx sigs: ${err.message}`
+				);
+			}
+		} finally {
+			this.confirmLoopRunning = false;
+		}
+	}
+
+	private recordEvictedTxSig(
+		_value: { ts: number },
+		key: string,
+		reason: string
+	) {
+		if (reason === 'evict') {
+			this.metrics.lruEvictedTxs++;
+			logger.info(`${LOG_PREFIX} Evicted tx from lru cache: ${key}`);
+		}
+	}
+
+	async addTxPayload(txPayload: IpcMessageMap[IpcMessageTypes.TRANSACTION]) {
+		this.txToSendPayload.push({
+			instruction: txPayload,
+			addressLookupTables: await Promise.all(
+				txPayload.addressLookupTables.map((lut) =>
+					this.mustGetAddressLookupTable(lut)
+				)
+			),
+		});
+	}
+
+	async addTxToConfirm(
+		txPayload: IpcMessageMap[IpcMessageTypes.CONFIRM_TRANSACTION]
+	) {
+		this.pendingTxSigsToConfirm.set(txPayload.confirmTxSig, {
+			ts: Date.now(),
+			slot: this.slotSubscriber.getSlot(),
+		});
+		this.metrics.txAttempted++;
+	}
+
+	addSigner(signerKey: string, signerInfo: string) {
+		const keypair = loadKeypair(signerInfo);
+		logger.info(
+			`${LOG_PREFIX} adding new signer: ${signerKey}: info: ${signerInfo.slice(
+				0,
+				10
+			)}... (${signerInfo.length} len), ${keypair.publicKey.toBase58()}`
+		);
+		this.listenToTxLogs(keypair.publicKey);
+		this.signers.set(signerKey, new AnchorWallet(keypair));
+	}
+
+	async addAddressLookupTable(address: string) {
+		if (!this.addressLookupTables.has(address)) {
+			logger.info(`${LOG_PREFIX} adding new address lookup table: ${address}`);
+			const resp = await this.connection.getAddressLookupTable(
+				new PublicKey(address)
+			);
+			if (resp.value) {
+				this.addressLookupTables.set(address, resp.value);
+			} else {
+				logger.error(
+					`${LOG_PREFIX} Failed to get address lookup table for ${address}`
+				);
+			}
+		}
+	}
+
+	async mustGetAddressLookupTable(
+		address: string
+	): Promise<AddressLookupTableAccount> {
+		if (!this.addressLookupTables.has(address)) {
+			logger.error(
+				`${LOG_PREFIX} Address lookup table not found for ${address}, adding it...`
+			);
+			await this.addAddressLookupTable(address);
+		}
+		return this.addressLookupTables.get(address)!;
+	}
+
+	private async buildTransactionToSend(
+		ixs: TransactionInstruction[],
+		lookupTableAccounts: AddressLookupTableAccount[] | undefined,
+		payerPublicKey: PublicKey,
+		simulateForCus = true
+	): Promise<{
+		simResult: SimulateAndGetTxWithCUsResponse;
+		blockhash: BlockhashWithExpiryBlockHeight;
+	}> {
+		const blockhash = this.blockhashSubscriber.getLatestBlockhash(5);
+		const simResult = await simulateAndGetTxWithCUs({
+			ixs,
+			connection: this.connection,
+			payerPublicKey,
+			lookupTableAccounts: lookupTableAccounts ?? [],
+			cuLimitMultiplier: 1.1,
+			doSimulation: simulateForCus,
+			recentBlockhash: blockhash?.blockhash,
+		});
+
+		return {
+			simResult,
+			blockhash: blockhash!,
+		};
+	}
+
+	private async sendVersionedTransaction(
+		tx: VersionedTransaction,
+		signers: Signer[],
+		opts?: ConfirmOptions
+	): Promise<{ txRaw: Buffer | Uint8Array; txSig: TransactionSignature }> {
+		tx.sign(signers);
+		const txRaw = tx.serialize();
+		this.sendRawTransaction(txRaw, opts);
+
+		const txSig = bs58.encode(tx.signatures[0]);
+		return {
+			txRaw,
+			txSig,
+		};
+	}
+
+	private sendToAdditionalConnections(
+		rawTx: Buffer | Uint8Array,
+		opts?: ConfirmOptions
+	): void {
+		this.additionalSendTxConnections.map((connection: Connection) => {
+			connection.sendRawTransaction(rawTx, opts).catch((e) => {
+				console.error(
+					// @ts-ignore
+					`${LOG_PREFIX} error sending tx to additional connection: ${connection._rpcEndpoint}`
+				);
+				console.error(e);
+			});
+		});
+	}
+
+	private sendRawTransaction(
+		rawTransaction: Buffer | Uint8Array,
+		opts?: ConfirmOptions
+	) {
+		this.connection.sendRawTransaction(rawTransaction, opts);
+		this.sendToAdditionalConnections(rawTransaction, opts);
+	}
+
+	private async runTxSenderLoop() {
+		const work = this.txToSendPayload.shift();
+		if (!work) {
+			return;
+		}
+
+		// 1) handle any expired transactions
+		let txExpired = false;
+		if (work.blockhashExpiryHeight) {
+			const blockHeight = this.blockhashSubscriber.getLatestBlockHeight();
+			if (blockHeight > work.blockhashExpiryHeight) {
+				logger.info(
+					`${LOG_PREFIX} Blockhash expired for tx: ${work.lastSentTxSig}, retrying: ${work.instruction.retryUntilConfirmed}`
+				);
+				if (work.instruction.retryUntilConfirmed) {
+					txExpired = true;
+				} else {
+					this.pendingTxSigsToConfirm.delete(work.lastSentTxSig!);
+					this.metrics.txDroppedBlockhashExpired++;
+					return;
+				}
+			}
+		}
+
+		const now = Date.now();
+		const txReadyToRetry = now > (work.lastSendTs ?? 0) + this.resendInterval;
+		const firstTimeSendingTx = work.lastSendTs === undefined;
+		const txPreviouslySent = work.lastSentRawTx !== undefined;
+
+		// 2) check if the tx has been confirmed
+		if (!firstTimeSendingTx) {
+			if (!this.pendingTxSigsToConfirm.has(work.lastSentTxSig!)) {
+				return;
+			}
+		}
+
+		// 3) send the tx if it's the first time or ready to retry
+		// Build a new tx with a fresh blockhash. TODO: need a fresh priority fee?
+		if (txExpired || firstTimeSendingTx) {
+			const signers: AnchorWallet[] = [];
+			for (const signerKey of work.instruction.signerKeys) {
+				const signer = this.signers.get(signerKey);
+				if (!signer) {
+					throw new Error(`${LOG_PREFIX} Signer not found for ${signerKey}`);
+				}
+				signers.push(signer);
+			}
+			if (signers.length === 0) {
+				throw new Error(`${LOG_PREFIX} No signers found for tx`);
+			}
+
+			const { simResult, blockhash } = await this.buildTransactionToSend(
+				work.instruction.ixs,
+				work.addressLookupTables,
+				signers[0].publicKey,
+				work.instruction.simulateCUs
+			);
+
+			if (simResult.simError === null) {
+				work.lastSendTs = Date.now();
+				if (this.sendTxEnabled) {
+					const txResp = await this.sendVersionedTransaction(
+						simResult.tx,
+						signers.map((signer) => signer.payer),
+						this.sendTxOpts
+					);
+					work.lastSentTxSig = txResp.txSig;
+					work.lastSentTx = simResult.tx;
+					work.lastSentRawTx = txResp.txRaw;
+					work.blockhashExpiryHeight = blockhash.lastValidBlockHeight;
+					work.blockhashUsed = blockhash.blockhash;
+					this.pendingTxSigsToConfirm.set(work.lastSentTxSig!, {
+						ts: Date.now(),
+						slot: this.slotSubscriber.getSlot(),
+						simSlot: simResult.simSlot,
+					});
+					this.txToSendPayload.push(work);
+				} else {
+					logger.info(
+						`${LOG_PREFIX} sendTxEnabled=false, cuEst: ${
+							simResult.cuEstimate
+						} simError: ${JSON.stringify(
+							simResult.simError
+						)}, sim tx logs:\n${JSON.stringify(simResult.simTxLogs, null, 2)}`
+					);
+				}
+				this.metrics.txAttempted++;
+			} else {
+				this.metrics.txFailedSimulation++;
+				logger.error(
+					`${LOG_PREFIX} TxSimulationFailed: ${JSON.stringify(
+						simResult.simError
+					)}: simLogs:\n${JSON.stringify(simResult.simTxLogs, null, 2)}`
+				);
+			}
+		} else if (txPreviouslySent && txReadyToRetry) {
+			if (work.instruction.simOnRetry && work.lastSentTx) {
+				const simResp = await this.connection.simulateTransaction(
+					work.lastSentTx,
+					{
+						sigVerify: false,
+						replaceRecentBlockhash: true,
+						commitment: 'processed',
+					}
+				);
+				if (simResp.value.err !== null) {
+					logger.error(
+						`${LOG_PREFIX} TxSimulationFailed: ${JSON.stringify(
+							simResp.value.err
+						)}\n${JSON.stringify(simResp.value.logs)}`
+					);
+					this.metrics.txFailedSimulation++;
+					return;
+				}
+			}
+			if (this.sendTxEnabled) {
+				this.sendRawTransaction(work.lastSentRawTx!, this.sendTxOpts);
+				work.lastSendTs = Date.now();
+				this.txToSendPayload.push(work);
+				this.metrics.txRetried++;
+			} else {
+				logger.info(
+					`${LOG_PREFIX} sendTxEnabled=false, skipping retry ${work.lastSentTxSig}`
+				);
+			}
+		} else {
+			// not ready to retry, push it back to the queue
+			this.txToSendPayload.push(work);
+		}
+	}
+
+	private async startTxSenderLoop() {
+		logger.info(`${LOG_PREFIX} TxSender started`);
+		while (this.running) {
+			try {
+				await this.runTxSenderLoop();
+			} catch (e) {
+				const err = e as Error;
+				logger.error(
+					`${LOG_PREFIX} Error in txSenderLoop: ${err.message}\n${err.stack}`
+				);
+			}
+
+			// let the event loop run
+			await sleepMs(10);
+		}
+		logger.info(`${LOG_PREFIX} TxSender stopped`);
+	}
+}

--- a/src/bots/common/threads/txThread.ts
+++ b/src/bots/common/threads/txThread.ts
@@ -1,0 +1,152 @@
+import { logger } from '../../../logger';
+import { TxSender } from './txSender';
+import {
+	IpcMessage,
+	IpcMessageMap,
+	IpcMessageTypes,
+	WrappedIpcMessage,
+	deserializedIx,
+} from './types';
+import { BlockhashSubscriber, SlotSubscriber } from '@drift-labs/sdk';
+import { Connection } from '@solana/web3.js';
+import dotenv from 'dotenv';
+import parseArgs from 'minimist';
+
+const logPrefix = 'TxThread';
+
+function sendToParent(msgType: IpcMessageTypes, data: IpcMessage) {
+	process.send!({
+		type: msgType,
+		data,
+	} as WrappedIpcMessage);
+}
+
+const main = async () => {
+	// kill this process if the parent dies
+	process.on('disconnect', () => process.exit());
+	dotenv.config();
+
+	const args = parseArgs(process.argv.slice(2));
+	logger.info(`[${logPrefix}] Started with args: ${JSON.stringify(args)}`);
+	const rpcUrl = args['rpc'];
+	const sendTxEnabled = args['send-tx'] === 'true';
+
+	if (process.send === undefined) {
+		logger.error(
+			`[${logPrefix}] Error spawning process: process.send is not a function`
+		);
+		process.exit(1);
+	}
+
+	const blockhashSubscriber = new BlockhashSubscriber({
+		rpcUrl,
+		commitment: 'finalized',
+		updateIntervalMs: 3000,
+	});
+	await blockhashSubscriber.subscribe();
+
+	const connection = new Connection(rpcUrl);
+	const slotSubscriber = new SlotSubscriber(connection);
+	await slotSubscriber.subscribe();
+
+	const txSender = new TxSender({
+		connection,
+		blockhashSubscriber,
+		slotSubscriber,
+		resendInterval: 1000,
+		sendTxEnabled,
+	});
+	await txSender.subscribe();
+
+	const metricsSenderId = setInterval(async () => {
+		sendToParent(IpcMessageTypes.METRICS, txSender.getMetrics());
+	}, 10_000);
+
+	sendToParent(IpcMessageTypes.NOTIFICATION, {
+		message: 'Started',
+	});
+
+	const shutdown = async () => {
+		clearInterval(metricsSenderId);
+
+		blockhashSubscriber.unsubscribe();
+		await txSender.unsubscribe();
+	};
+
+	process.on('SIGINT', async () => {
+		console.log(`TxSender Received SIGINT, shutting down...`);
+		await shutdown();
+		process.exit(0);
+	});
+
+	process.on('SIGTERM', async () => {
+		console.log(`TxSender Received SIGTERM, shutting down...`);
+		await shutdown();
+		process.exit(0);
+	});
+
+	process.on('message', async (_msg: WrappedIpcMessage, _sendHandle: any) => {
+		switch (_msg.type) {
+			case IpcMessageTypes.NOTIFICATION: {
+				const notification =
+					_msg.data as IpcMessageMap[IpcMessageTypes.NOTIFICATION];
+				if (notification.message === 'close') {
+					logger.info(`Parent close notification ${notification.message}`);
+					process.exit(0);
+				}
+				logger.info(`Notification from parent: ${notification.message}`);
+				break;
+			}
+			case IpcMessageTypes.NEW_SIGNER: {
+				const signerPayload =
+					_msg.data as IpcMessageMap[IpcMessageTypes.NEW_SIGNER];
+				txSender.addSigner(signerPayload.signerKey, signerPayload.signerInfo);
+				break;
+			}
+			case IpcMessageTypes.NEW_ADDRESS_LOOKUP_TABLE: {
+				const addressLookupTablePayload =
+					_msg.data as IpcMessageMap[IpcMessageTypes.NEW_ADDRESS_LOOKUP_TABLE];
+				await txSender.addAddressLookupTable(addressLookupTablePayload.address);
+				break;
+			}
+			case IpcMessageTypes.TRANSACTION: {
+				const txPayload =
+					_msg.data as IpcMessageMap[IpcMessageTypes.TRANSACTION];
+
+				if (txPayload.newSigners?.length > 0) {
+					for (const signer of txPayload.newSigners) {
+						txSender.addSigner(signer.key, signer.info);
+					}
+				}
+
+				txPayload.ixs = txPayload.ixsSerialized.map((ix) => deserializedIx(ix));
+				await txSender.addTxPayload(txPayload);
+				break;
+			}
+			case IpcMessageTypes.CONFIRM_TRANSACTION: {
+				const confirmPayload =
+					_msg.data as IpcMessageMap[IpcMessageTypes.CONFIRM_TRANSACTION];
+				txSender.addTxToConfirm(confirmPayload);
+				break;
+			}
+			case IpcMessageTypes.SET_TRANSACTIONS_ENABLED: {
+				const txPayload =
+					_msg.data as IpcMessageMap[IpcMessageTypes.SET_TRANSACTIONS_ENABLED];
+				logger.info(`Parent set transactions enabled: ${txPayload.txEnabled}`);
+				txSender.setTransactionsEnabled(txPayload.txEnabled);
+				break;
+			}
+			default: {
+				logger.info(
+					`Unknown message type from parent: ${JSON.stringify(_msg)}`
+				);
+				break;
+			}
+		}
+	});
+};
+
+main().catch((err) => {
+	logger.error(`[${logPrefix}] Error in TxThread: ${JSON.stringify(err)}`);
+	process.exit(1);
+});

--- a/src/bots/common/threads/types.ts
+++ b/src/bots/common/threads/types.ts
@@ -1,0 +1,132 @@
+import {
+	AddressLookupTableAccount,
+	PublicKey,
+	TransactionInstruction,
+	VersionedTransaction,
+} from '@solana/web3.js';
+
+export type WrappedIpcMessage = {
+	type: IpcMessageTypes;
+	data: IpcMessage;
+};
+
+export enum IpcMessageTypes {
+	COMMAND = 'command',
+	NOTIFICATION = 'notification',
+	NEW_SIGNER = 'new_signer',
+	NEW_ADDRESS_LOOKUP_TABLE = 'new_address_lookup_table',
+	TRANSACTION = 'transaction',
+	CONFIRM_TRANSACTION = 'confirm_transaction',
+	SET_TRANSACTIONS_ENABLED = 'set_transactions_enabled',
+	METRICS = 'metrics',
+}
+
+export type Serializable =
+	| string
+	| number
+	| boolean
+	| null
+	| Serializable[]
+	| { [key: string]: Serializable };
+
+export type IpcMessageMap = {
+	[IpcMessageTypes.COMMAND]: {
+		command: string;
+	};
+	[IpcMessageTypes.NOTIFICATION]: {
+		message: string;
+	};
+	[IpcMessageTypes.NEW_SIGNER]: {
+		signerKey: string;
+		signerInfo: string;
+	};
+	[IpcMessageTypes.NEW_ADDRESS_LOOKUP_TABLE]: {
+		address: string;
+	};
+	[IpcMessageTypes.TRANSACTION]: {
+		ixsSerialized: object[];
+		/// deserialized instructions
+		ixs: TransactionInstruction[];
+		/// true to simulate the tx before retrying.
+		simOnRetry: boolean;
+		/// true to simulate the tx with CUs
+		simulateCUs: boolean;
+		/// instructs the TxThread to retry this tx with a new blockhash until it goes through
+		retryUntilConfirmed: boolean;
+		/// ID of signer(s) for the tx. Needs to be added via IpcMessageTypes.NEW_SIGNER before, otherwise will throw.
+		signerKeys: string[];
+		/// Pubkey of address lookup tables for the tx. Needs to be added via IpcMessageTypes.NEW_ADDRESS_LOOKUP_TABLE before, otherwise will throw.
+		addressLookupTables: string[];
+		/// New signers for the tx, use this instead of sending a IpcMessageTypes.NEW_SIGNER
+		newSigners: { key: string; info: string }[];
+	};
+	[IpcMessageTypes.CONFIRM_TRANSACTION]: {
+		/// transaction signature to confirm, signer for the tx must be previously registered with IpcMessageTypes.NEW_SIGNER, or passed in newSigners
+		confirmTxSig: string;
+		/// New signers for the tx, use this instead of sending a IpcMessageTypes.NEW_SIGNER
+		newSigners: { key: string; info: string }[];
+	};
+	[IpcMessageTypes.SET_TRANSACTIONS_ENABLED]: {
+		txEnabled: boolean;
+	};
+	[IpcMessageTypes.METRICS]: TxSenderMetrics;
+};
+
+export type IpcMessage = IpcMessageMap[keyof IpcMessageMap];
+
+export type TxSenderMetrics = {
+	txLanded: number;
+	txAttempted: number;
+	txDroppedTimeout: number;
+	txDroppedBlockhashExpired: number;
+	txFailedSimulation: number;
+	txRetried: number;
+	lruEvictedTxs: number;
+	pendingQueueSize: number;
+	confirmQueueSize: number;
+	txConfirmRateLimited: number;
+	txEnabled: number;
+	txConfirmedFromWs: number;
+};
+
+/// States for transactions going through the txThread
+export enum TxState {
+	/// the tx is queued and has not been sent yet
+	QUEUED = 'queued',
+	/// the tx has been sent at least once
+	RETRYING = 'retrying',
+	/// the tx has failed (blockhash expired)
+	FAILED = 'failed',
+	/// the tx has landed (confirmed)
+	LANDED = 'landed',
+}
+
+export type TransactionPayload = {
+	instruction: IpcMessageMap[IpcMessageTypes.TRANSACTION];
+	retries?: number;
+	blockhashUsed?: string;
+	blockhashExpiryHeight?: number;
+	lastSentTxSig?: string;
+	lastSentTx?: VersionedTransaction;
+	lastSentRawTx?: Buffer | Uint8Array;
+	lastSendTs?: number;
+	addressLookupTables?: AddressLookupTableAccount[];
+};
+
+export function deserializedIx(ix: any): TransactionInstruction {
+	let keys = ix['keys'] as any[];
+	if (keys.length > 0) {
+		keys = keys.map((k: any) => {
+			return {
+				pubkey: new PublicKey(k['pubkey'] as string),
+				isSigner: k['isSigner'] as boolean,
+				isWritable: k['isWritable'] as boolean,
+			};
+		});
+	}
+	return {
+		keys,
+		programId: new PublicKey(ix['programId']),
+		data: Buffer.from(ix['data']),
+	};
+}

--- a/src/bots/common/txThreaded.ts
+++ b/src/bots/common/txThreaded.ts
@@ -1,0 +1,324 @@
+import { logger } from '../../logger';
+import { GaugeValue, Metrics } from '../../metrics';
+import { spawnChildWithRetry } from './processUtils';
+import {
+	IpcMessageMap,
+	IpcMessageTypes,
+	WrappedIpcMessage,
+	TxSenderMetrics,
+} from './threads/types';
+import { TransactionInstruction } from '@solana/web3.js';
+import { ChildProcess, SendHandle, Serializable } from 'child_process';
+import path from 'path';
+
+export class TxThreaded {
+	protected txThreadProcess?: ChildProcess;
+	protected txSendMetricsGauge?: GaugeValue;
+	protected _lastTxMetrics?: TxSenderMetrics;
+	protected _lastTxThreadMetricsReceived: number;
+	private _botIdString: string;
+
+	constructor(botIdString?: string) {
+		this._botIdString = botIdString ?? '';
+		this._lastTxThreadMetricsReceived = 0;
+	}
+	get lastTxThreadMetricsReceived(): number {
+		return this._lastTxThreadMetricsReceived;
+	}
+
+	get pendingQueueSize(): number {
+		return this.pendingQueueSize;
+	}
+
+	public txThreadSetName(name: string) {
+		this._botIdString = name;
+	}
+
+	/**
+	 * Sends a notification to the txThread to close and waits for it to exit
+	 */
+	protected async terminateTxThread() {
+		if (!this.txThreadProcess) {
+			logger.info(`[TxThreaded] No txThread process to terminate`);
+			return;
+		}
+
+		this.txThreadProcess.send({
+			type: IpcMessageTypes.NOTIFICATION,
+			data: {
+				message: 'close',
+			},
+		});
+
+		// terminate child txThread
+		logger.info(`[TxThreaded] Waiting 5s for txThread to close...`);
+		for (let i = 0; i < 5; i++) {
+			if (
+				this.txThreadProcess.exitCode !== null ||
+				this.txThreadProcess.killed
+			) {
+				break;
+			}
+			logger.info(`[TxThreaded] Child thread still alive ...`);
+			await new Promise((resolve) => setTimeout(resolve, 1000));
+		}
+
+		if (!this.txThreadProcess.killed) {
+			logger.info(`[TxThreaded] Child thread still alive 🔪...`);
+			this.txThreadProcess.kill();
+		}
+		logger.info(
+			`[TxThreaded] Child thread exit code: ${this.txThreadProcess.exitCode}`
+		);
+	}
+
+	protected initializeTxThreadMetrics(metrics: Metrics, meterName: string) {
+		this.txSendMetricsGauge = metrics.addGauge(
+			'tx_sender_metrics',
+			'TxSender thread metrics',
+			meterName
+		);
+	}
+
+	/**
+	 * Spawns the txThread process
+	 */
+	protected initTxThread(rpcUrl?: string) {
+		// @ts-ignore - This is how to check for tsx unfortunately https://github.com/privatenumber/tsx/issues/49
+		const isTsx: boolean = process._preload_modules.some((m: string) =>
+			m.includes('tsx')
+		);
+		const isTsNode = process.argv.some((arg) => arg.includes('ts-node'));
+		const isBun = process.versions.bun;
+		const isTs = isTsNode || isTsx || isBun;
+		const txThreadFileName = isTs ? 'txThread.ts' : 'txThread.js';
+
+		logger.info(
+			`[TxThreaded] isTsNode or tsx: ${isTs}, txThreadFileName: ${txThreadFileName}, argv: ${JSON.stringify(
+				process.argv
+			)}`
+		);
+
+		const rpcEndpoint =
+			rpcUrl ?? process.env.ENDPOINT ?? process.env.RPC_HTTP_URL;
+
+		if (!rpcEndpoint) {
+			throw new Error(
+				'Must supply a Solana RPC endpoint through config file or env vars ENDPOINT or RPC_HTTP_URL'
+			);
+		}
+
+		// {@link ./threads/txThread.ts}
+		this.txThreadProcess = spawnChildWithRetry(
+			path.join(__dirname, './threads', txThreadFileName),
+			[`--rpc=${rpcEndpoint}`, `--send-tx=false`], // initially disable transactions
+			'txThread',
+			(_msg: Serializable, _sendHandle: SendHandle) => {
+				const msg = _msg as WrappedIpcMessage;
+				switch (msg.type) {
+					case IpcMessageTypes.NOTIFICATION: {
+						const notification =
+							msg.data as IpcMessageMap[IpcMessageTypes.NOTIFICATION];
+						logger.info(`Notification from child: ${notification.message}`);
+						break;
+					}
+					case IpcMessageTypes.METRICS: {
+						const txMetrics =
+							msg.data as IpcMessageMap[IpcMessageTypes.METRICS];
+						const now = Date.now();
+						this._lastTxThreadMetricsReceived = now;
+						this._lastTxMetrics = txMetrics;
+
+						if (!this.txSendMetricsGauge) {
+							break;
+						}
+
+						this.txSendMetricsGauge!.setLatestValue(now, {
+							metric: 'txMetricsLastTs',
+						});
+						this.txSendMetricsGauge!.setLatestValue(txMetrics.txLanded, {
+							metric: 'txLanded',
+						});
+						this.txSendMetricsGauge!.setLatestValue(txMetrics.txRetried, {
+							metric: 'txRetried',
+						});
+						this.txSendMetricsGauge!.setLatestValue(txMetrics.txAttempted, {
+							metric: 'txAttempted',
+						});
+						this.txSendMetricsGauge!.setLatestValue(
+							txMetrics.txDroppedBlockhashExpired,
+							{
+								metric: 'txDroppedBlockhashExpired',
+							}
+						);
+						this.txSendMetricsGauge!.setLatestValue(txMetrics.txEnabled, {
+							metric: 'txEnabled',
+						});
+						this.txSendMetricsGauge!.setLatestValue(txMetrics.lruEvictedTxs, {
+							metric: 'lruEvictedTxs',
+						});
+						this.txSendMetricsGauge!.setLatestValue(
+							txMetrics.pendingQueueSize,
+							{
+								metric: 'pendingQueueSize',
+							}
+						);
+						this.txSendMetricsGauge!.setLatestValue(
+							txMetrics.confirmQueueSize,
+							{
+								metric: 'confirmQueueSize',
+							}
+						);
+						this.txSendMetricsGauge!.setLatestValue(
+							txMetrics.txFailedSimulation,
+							{
+								metric: 'txFailedSimulation',
+							}
+						);
+						this.txSendMetricsGauge!.setLatestValue(
+							txMetrics.txConfirmedFromWs,
+							{
+								metric: 'txConfirmedFromWs',
+							}
+						);
+						break;
+					}
+					default: {
+						logger.info(
+							`Unknown message type from child: ${JSON.stringify(_msg)}`
+						);
+						break;
+					}
+				}
+			},
+			`[${this._botIdString}]`
+		);
+	}
+
+	/**
+	 * Sends signer info for the tx thread to sign txs with.
+	 * @param signerKey - public key of the signer, used to id the signer
+	 * @param signerInfo - Raw private key or file to open, to be passed into `loadKeypair`
+	 */
+	protected async sendSignerToTxThread(signerKey: string, signerInfo: string) {
+		if (!this.txThreadProcess) {
+			logger.error(`[TxThreaded] No txThread process to send signer to`);
+			return;
+		}
+
+		this.txThreadProcess.send({
+			type: IpcMessageTypes.NEW_SIGNER,
+			data: {
+				signerKey,
+				signerInfo,
+			},
+		});
+	}
+
+	/**
+	 * Sends an address lookup table to the tx thread, needed when resigning txs for retry
+	 * @param address - address of the lookup table
+	 */
+	protected async sendAddressLutToTxThread(address: string) {
+		if (!this.txThreadProcess) {
+			logger.error(
+				`[TxThreaded] No txThread process to send address lookup table to`
+			);
+			return;
+		}
+
+		this.txThreadProcess.send({
+			type: IpcMessageTypes.NEW_ADDRESS_LOOKUP_TABLE,
+			data: {
+				address,
+			},
+		});
+	}
+
+	/**
+	 * Sends a transaction to the tx thread to be signed and sent
+	 * @param ixs - instructions to send
+	 * @param signerKeys - public keys of the signers (must previously be registerd with `sendSignerToTxThread`)
+	 * @param addressLookupTables - addresses of the address lookup tables (must previously be registerd with `sendAddressLutToTxThread`)
+	 * @param newSigners - new signers to add (identical to registering with `sendSignerToTxThread`)
+	 */
+	protected async sendIxsToTxthread({
+		ixs,
+		signerKeys,
+		doSimulation,
+		addressLookupTables = [],
+		newSigners = [],
+	}: {
+		ixs: TransactionInstruction[];
+		signerKeys: string[];
+		doSimulation: boolean;
+		addressLookupTables?: string[];
+		newSigners?: { key: string; info: string }[];
+	}) {
+		if (!this.txThreadProcess) {
+			logger.error(`[TxThreaded] No txThread process to send instructions to`);
+			return;
+		}
+
+		this.txThreadProcess.send({
+			type: IpcMessageTypes.TRANSACTION,
+			data: {
+				ixsSerialized: ixs,
+				doSimulation,
+				simulateCUs: true,
+				retryUntilConfirmed: false,
+				signerKeys,
+				addressLookupTables,
+				newSigners,
+			},
+		});
+	}
+
+	/**
+	 * Sends a transaction signature to the tx thread to be confirmed. The signer of the tx sig must be previously registered with `sendSignerToTxThread`.
+	 * @param txSig - transaction signature to confirm
+	 * @param signerKeys - public keys of the signers (must previously be registerd with `sendSignerToTxThread`)
+	 * @param addressLookupTables - addresses of the address lookup tables (must previously be registerd with `sendAddressLutToTxThread`)
+	 * @param newSigners - new signers to add (identical to registering with `sendSignerToTxThread`)
+	 */
+	protected async registerTxToConfirm({
+		txSig,
+		newSigners = [],
+	}: {
+		txSig: string;
+		newSigners?: { key: string; info: string }[];
+	}) {
+		if (!this.txThreadProcess) {
+			logger.error(`[TxThreaded] No txThread process to send instructions to`);
+			return;
+		}
+
+		this.txThreadProcess.send({
+			type: IpcMessageTypes.CONFIRM_TRANSACTION,
+			data: {
+				confirmTxSig: txSig,
+				newSigners,
+			},
+		});
+	}
+
+	/**
+	 * Enables or disables transactions for the tx thread
+	 * @param state - true to enable transactions, false to disable
+	 */
+	protected async setTxEnabledTxThread(state: boolean) {
+		if (!this.txThreadProcess) {
+			logger.error(
+				`[TxThreaded] No txThread process to set transaction enabled state`
+			);
+			return;
+		}
+
+		this.txThreadProcess.send({
+			type: IpcMessageTypes.SET_TRANSACTIONS_ENABLED,
+			data: {
+				txEnabled: state,
+			},
+		});
+	}
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -144,7 +144,9 @@ export type BotConfigMap = {
 
 export interface GlobalConfig {
 	driftEnv: DriftEnv;
+	/// rpc endpoint to use
 	endpoint: string;
+	/// ws endpoint to use (inferred from endpoint using web3.js rules, only provide if you want to use a different one)
 	wsEndpoint?: string;
 	hermesEndpoint?: string;
 	numNonActiveOraclesToPush?: number;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -468,6 +468,7 @@ export type SimulateAndGetTxWithCUsResponse = {
 	cuEstimate: number;
 	simTxLogs: Array<string> | null;
 	simError: TransactionError | string | null;
+	simSlot: number;
 	simTxDuration: number;
 	tx: VersionedTransaction;
 };
@@ -523,6 +524,7 @@ export async function simulateAndGetTxWithCUs(
 			cuEstimate: -1,
 			simTxLogs: null,
 			simError: null,
+			simSlot: -1,
 			simTxDuration,
 			tx,
 		};
@@ -595,6 +597,7 @@ export async function simulateAndGetTxWithCUs(
 		simTxLogs,
 		simTxDuration,
 		simError: resp.value.err,
+		simSlot: resp.context.slot,
 		tx: txWithCUs,
 	};
 }


### PR DESCRIPTION
Add a base class `TxThreaded` that `Bot`s can extend to  get tx sending and land rate tracking in a separate process. The spawned process handles signing and sending transactions via [generally recommended practices](https://docs.triton.one/chains/solana/sending-txs), retrying on a 1s interval, and listening to  `logSubscribe` for transactions mentioning pubkeys registered via `TxThreaded.sendSignerToTxThread` 


If metrics are enabled, the following metrics are added via `TxThreaded`:
```
# HELP tx_sender_metrics TxSender thread metrics
# TYPE tx_sender_metrics gauge
tx_sender_metrics{metric="txMetricsLastTs"} 1724718213292 1724718222738
tx_sender_metrics{metric="txLanded"} 243 1724718222738
tx_sender_metrics{metric="txRetried"} 0 1724718222738
tx_sender_metrics{metric="txAttempted"} 278 1724718222738
tx_sender_metrics{metric="txDroppedBlockhashExpired"} 0 1724718222738
tx_sender_metrics{metric="txEnabled"} 1 1724718222738
tx_sender_metrics{metric="lruEvictedTxs"} 0 1724718222738
tx_sender_metrics{metric="pendingQueueSize"} 0 1724718222738
tx_sender_metrics{metric="confirmQueueSize"} 20 1724718222738
tx_sender_metrics{metric="txFailedSimulation"} 0 1724718222738
tx_sender_metrics{metric="txConfirmedFromWs"} 243 1724718222738
```