### PR TITLE
Move cooldown timer to immediately after filter

### DIFF
--- a/src/experimental-bots/filler/fillerMultithreaded.ts
+++ b/src/experimental-bots/filler/fillerMultithreaded.ts
@@ -1347,7 +1347,11 @@ export class FillerMultithreaded {
 				return false;
 			}
 			seenTriggerableNodes.add(sig);
-			return this.filterTriggerableNodes(node);
+			if (this.filterTriggerableNodes(node, sig)) {
+				this.triggeringNodes.set(sig, Date.now());
+				return true;
+			}
+			return false;
 		});
 		logger.debug(
 			`${logPrefix} Filtered down to ${filteredTriggerableNodes.length} triggerable nodes...`
@@ -1367,22 +1371,20 @@ export class FillerMultithreaded {
 	}
 
 	protected filterTriggerableNodes(
-		nodeToTrigger: SerializedNodeToTrigger
+		nodeToTrigger: SerializedNodeToTrigger,
+		signature: string
 	): boolean {
 		if (nodeToTrigger.node.haveTrigger) {
 			return false;
 		}
 
 		const now = Date.now();
-		const nodeToFillSignature = getNodeToTriggerSignature(nodeToTrigger);
-		const timeStartedToTriggerNode =
-			this.triggeringNodes.get(nodeToFillSignature);
+		const timeStartedToTriggerNode = this.triggeringNodes.get(signature);
 		if (timeStartedToTriggerNode) {
 			if (timeStartedToTriggerNode + TRIGGER_ORDER_COOLDOWN_MS > now) {
 				return false;
 			}
 		}
-
 		return true;
 	}
 


### PR DESCRIPTION
There is a race condition where the DLOB builder will send the same order to get triggered and we don't add it to the cooldown map fast enough so the same node get past the filter.
```mermaid
sequenceDiagram
    participant DLOB as fillerMultithreaded
    participant Map as Cooldown Map
    
    Note over DLOB, Map: Race Condition Problem
    
    DLOB->>DLOB: Finds order A-1172
    DLOB->>Map: Check: Is A-1172 in map?
    Map-->>DLOB: No (not yet added)
    DLOB->>DLOB: Begin processing A-1172
    
    DLOB->>DLOB: Finds order A-1172 again
    DLOB->>Map: Check: Is A-1172 in map?
    Map-->>DLOB: No (still not added)
    DLOB->>DLOB: Begin processing A-1172 again
    
    Note over DLOB, Map: Same order processed twice!
    
    DLOB->>Map: Add A-1172 to map (first process)
    DLOB->>Map: Add A-1172 to map (second process)
    
    Note over Map: Too late - duplicate processing already occurred
```